### PR TITLE
deactivate and stop nextdns before uninstall

### DIFF
--- a/.goreleaser/preremove.sh
+++ b/.goreleaser/preremove.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 if nextdns status > /dev/null 2>&1; then
+    nextdns deactivate
+    nextdns stop
     nextdns uninstall
 fi
 


### PR DESCRIPTION
- if not deactivated before uninstall, generates a `/etc/resolve.conf` error as nameserver 127.0.0.1 exists
- deactivation is required else manual change of nameserver is needed
- even after reinstall the previous backup exists and not able to activate
`Error: setup resolv.conf: /etc/resolv.conf.nextdns-bak: file exists`
fixes https://github.com/nextdns/nextdns/issues/20

