### PR TITLE
Add Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ sudo apt update
 sudo apt install nextdns
 ```
 
+#### Arch Linux (AUR)
+
+```
+sudo pacman -S yay
+yay -S nextdns
+```
+
 #### MacOS
 
 Install [homebrew](https://brew.sh) first.


### PR DESCRIPTION
nextdns can now be installed from Arch Linux AUR as I added a PKGBUILD there.