### PR TITLE
Unset TZ variable to fix time zone in syslog

### DIFF
--- a/host/service/merlin/service.go
+++ b/host/service/merlin/service.go
@@ -199,6 +199,7 @@ case "$1" in
 				export SSL_CERT_FILE=/rom/ca-bundle.crt
 			fi
 			setup_tz
+			unset TZ
 			export {{.RunModeEnv}}=1
 			$cmd &
 			echo $! > "$pid_file"


### PR DESCRIPTION
localtime is ignored if TZ variable is set.