### PR TITLE
fix: nil pointer dereference on cache object

### DIFF
--- a/run.go
+++ b/run.go
@@ -190,10 +190,15 @@ func run(args []string) error {
 		})
 	}
 
-	var cache *lru.ARCCache
-	cacheSize, err := config.ParseBytes(c.CacheSize)
-	if err != nil {
-		return fmt.Errorf("%s: cannot parse cache size: %v", c.CacheSize, err)
+	var (
+		cache resolver.Cacher
+		cacheSize uint64
+	)
+	if c.CacheSize != "" {
+		cacheSize, err = config.ParseBytes(c.CacheSize)
+		if err != nil {
+			return fmt.Errorf("%s: cannot parse cache size: %v", c.CacheSize, err)
+		}
 	}
 	if cacheSize > 0 {
 		if cache, err = lru.NewARC(int(cacheSize)); err != nil {


### PR DESCRIPTION
Also check for `cacheSize` empty value to avoid error from parser. For the cacher type see https://play.golang.org/p/CRpOu3IwuJE which (in my tests) resembles the current setup more or less and leads to nil pointer error since the type is not nil