### PR TITLE
Update Go version to match release.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:golang AS xgo
 
-FROM --platform=$BUILDPLATFORM golang:1.13-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.14.2-alpine AS build
 
 ENV CGO_ENABLED=0
 COPY --from=xgo / /


### PR DESCRIPTION
Updating Go version to sync with https://github.com/nextdns/nextdns/commit/372b627241e75fd0cc02621d09c8fc6f34d09ff2.