### PR TITLE
discovery/dhcp.go: Add isc-dhcpd leases on OPNSense

### DIFF
--- a/discovery/dhcp.go
+++ b/discovery/dhcp.go
@@ -18,6 +18,7 @@ type leaseFile struct {
 var leaseFiles = []leaseFile{
 	{"/var/run/dhcpd.leases", "isc-dhcpd"},
 	{"/var/lib/dhcp/dhcpd.leases", "isc-dhcpd"},
+	{"/var/dhcpd/var/db/dhcpd.leases", "isc-dhcpd"},
 	{"/var/lib/misc/dnsmasq.leases", "dnsmasq"},
 	{"/tmp/dnsmasq.leases", "dnsmasq"},
 	{"/tmp/dhcp.leases", "dnsmasq"},


### PR DESCRIPTION
On OPNSense, the DHCP leases are stored in `/var/dhcpd/var/db/dhcpd.leases`. This patch adds these to the `leaseFiles` array.

I don't know how you came up with the current list but if it's something evolving, here's a patch to make it also work under OPNSense (20.1+).