### PR TITLE
Corrects an error with empty call of printf() function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -165,8 +165,9 @@ uninstall_rpm() {
 }
 
 install_zypper() {
-    sudo zypper ar -f https://dl.bintray.com/nextdns/rpm/ nextdns &&
-        sudo zypper refresh && sudo zypper in -y nextdns
+    sudo zypper repos | grep -q nextdns >/dev/null && 
+        echo "Repository nextdns already exists. Skipping adding repository..." || sudo zypper ar -f https://dl.bintray.com/nextdns/rpm/ nextdns 
+    sudo zypper refresh && sudo zypper in -y nextdns
 }
 
 upgrade_zypper() {
@@ -174,7 +175,12 @@ upgrade_zypper() {
 }
 
 uninstall_zypper() {
-    sudo zypper remove nextdns
+    sudo zypper remove -y nextdns
+    case $(ask_bool 'Do you want to remove the repository from the repositories list?' true) in
+            true)
+                sudo zypper removerepo nextdns
+                ;;
+        esac
 }
 
 

--- a/install.sh
+++ b/install.sh
@@ -164,26 +164,6 @@ uninstall_rpm() {
     sudo yum uninstall -y nextdns
 }
 
-install_zypper() {
-    sudo zypper repos | grep -q nextdns >/dev/null && 
-        echo "Repository nextdns already exists. Skipping adding repository..." || sudo zypper ar -f https://dl.bintray.com/nextdns/rpm/ nextdns 
-    sudo zypper refresh && sudo zypper in -y nextdns
-}
-
-upgrade_zypper() {
-    sudo zypper up nextdns
-}
-
-uninstall_zypper() {
-    sudo zypper remove -y nextdns
-    case $(ask_bool 'Do you want to remove the repository from the repositories list?' true) in
-            true)
-                sudo zypper removerepo nextdns
-                ;;
-        esac
-}
-
-
 install_deb() {
     # Fallback on curl, some debian based distrib don't have wget while debian
     # doesn't have curl by default.
@@ -340,9 +320,6 @@ install_type() {
     case $OS in
     centos|fedora|rhel)
         echo "rpm"
-        ;;
-    opensuse-tumbleweed|opensuse)
-        echo "zypper"
         ;;
     debian|ubuntu|elementary|raspbian|linuxmint)
         echo "deb"
@@ -664,7 +641,7 @@ detect_os() {
             # shellcheck disable=SC1091
             dist=$(. /etc/os-release; echo "$ID")
             case $dist in
-            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus)
+            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|solus)
                 echo "$dist"; return 0
                 ;;
             esac
@@ -738,7 +715,7 @@ silent_exec() {
 
 bin_location() {
     case $OS in
-    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus)
+    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|solus)
         echo "/usr/bin/nextdns"
         ;;
     darwin|synology)

--- a/install.sh
+++ b/install.sh
@@ -365,7 +365,7 @@ install_type() {
     asuswrt-merlin)
         echo "merlin"
         ;;
-    edgeos|synology|clear-linux-os)
+    edgeos|synology|clear-linux-os|solus)
         echo "bin"
         ;;
     ddwrt)
@@ -664,7 +664,7 @@ detect_os() {
             # shellcheck disable=SC1091
             dist=$(. /etc/os-release; echo "$ID")
             case $dist in
-            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse)
+            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus)
                 echo "$dist"; return 0
                 ;;
             esac
@@ -738,7 +738,7 @@ silent_exec() {
 
 bin_location() {
     case $OS in
-    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse)
+    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus)
         echo "/usr/bin/nextdns"
         ;;
     darwin|synology)

--- a/install.sh
+++ b/install.sh
@@ -341,7 +341,7 @@ install_type() {
     centos|fedora|rhel)
         echo "rpm"
         ;;
-    opensuse-tumbleweed)
+    opensuse-tumbleweed|opensuse)
         echo "zypper"
         ;;
     debian|ubuntu|elementary|raspbian|linuxmint)
@@ -664,7 +664,7 @@ detect_os() {
             # shellcheck disable=SC1091
             dist=$(. /etc/os-release; echo "$ID")
             case $dist in
-            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed)
+            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse)
                 echo "$dist"; return 0
                 ;;
             esac
@@ -738,7 +738,7 @@ silent_exec() {
 
 bin_location() {
     case $OS in
-    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed)
+    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse)
         echo "/usr/bin/nextdns"
         ;;
     darwin|synology)

--- a/install.sh
+++ b/install.sh
@@ -402,10 +402,10 @@ get_config_id() {
             break
         else
             print "Invalid configuration ID."
-            print "\n"
+            print
             print "ID format is 6 alphanumerical lowercase characters (example: 123abc). "
             print "Your ID can be found on the Setup tab of https://my.nextdns.io."
-            print "\n"
+            print
         fi
     done
     echo "$CONFIG_ID"
@@ -426,8 +426,14 @@ log_error() {
 }
 
 print() {
-    # shellcheck disable=SC2059
-    printf "$@" >&2
+    if [ -z "$1" ]
+    then
+        printf "" >&2
+    else
+        # shellcheck disable=SC2059
+        printf "$@" >&2
+    fi
+    
 }
 
 doc() {

--- a/install.sh
+++ b/install.sh
@@ -164,6 +164,26 @@ uninstall_rpm() {
     sudo yum uninstall -y nextdns
 }
 
+install_zypper() {
+    sudo zypper repos | grep -q nextdns >/dev/null && 
+        echo "Repository nextdns already exists. Skipping adding repository..." || sudo zypper ar -f https://dl.bintray.com/nextdns/rpm/ nextdns 
+    sudo zypper refresh && sudo zypper in -y nextdns
+}
+
+upgrade_zypper() {
+    sudo zypper up nextdns
+}
+
+uninstall_zypper() {
+    sudo zypper remove -y nextdns
+    case $(ask_bool 'Do you want to remove the repository from the repositories list?' true) in
+            true)
+                sudo zypper removerepo nextdns
+                ;;
+        esac
+}
+
+
 install_deb() {
     # Fallback on curl, some debian based distrib don't have wget while debian
     # doesn't have curl by default.
@@ -320,6 +340,9 @@ install_type() {
     case $OS in
     centos|fedora|rhel)
         echo "rpm"
+        ;;
+    opensuse-tumbleweed|opensuse)
+        echo "zypper"
         ;;
     debian|ubuntu|elementary|raspbian|linuxmint)
         echo "deb"
@@ -641,7 +664,7 @@ detect_os() {
             # shellcheck disable=SC1091
             dist=$(. /etc/os-release; echo "$ID")
             case $dist in
-            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|solus)
+            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus)
                 echo "$dist"; return 0
                 ;;
             esac
@@ -715,7 +738,7 @@ silent_exec() {
 
 bin_location() {
     case $OS in
-    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|solus)
+    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus)
         echo "/usr/bin/nextdns"
         ;;
     darwin|synology)

--- a/install.sh
+++ b/install.sh
@@ -425,10 +425,10 @@ get_config_id() {
             break
         else
             print "Invalid configuration ID."
-            print
-            print "ID format is 6 alphanumerical lowercase characters (example: 123abc)."
+            print "\n"
+            print "ID format is 6 alphanumerical lowercase characters (example: 123abc). "
             print "Your ID can be found on the Setup tab of https://my.nextdns.io."
-            print
+            print "\n"
         fi
     done
     echo "$CONFIG_ID"

--- a/install.sh
+++ b/install.sh
@@ -164,6 +164,20 @@ uninstall_rpm() {
     sudo yum uninstall -y nextdns
 }
 
+install_zypper() {
+    sudo zypper ar -f https://dl.bintray.com/nextdns/rpm/ nextdns &&
+        sudo zypper refresh && sudo zypper in -y nextdns
+}
+
+upgrade_zypper() {
+    sudo zypper up nextdns
+}
+
+uninstall_zypper() {
+    sudo zypper remove nextdns
+}
+
+
 install_deb() {
     # Fallback on curl, some debian based distrib don't have wget while debian
     # doesn't have curl by default.
@@ -320,6 +334,9 @@ install_type() {
     case $OS in
     centos|fedora|rhel)
         echo "rpm"
+        ;;
+    opensuse-tumbleweed)
+        echo "zypper"
         ;;
     debian|ubuntu|elementary|raspbian|linuxmint)
         echo "deb"
@@ -641,7 +658,7 @@ detect_os() {
             # shellcheck disable=SC1091
             dist=$(. /etc/os-release; echo "$ID")
             case $dist in
-            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint)
+            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed)
                 echo "$dist"; return 0
                 ;;
             esac
@@ -715,7 +732,7 @@ silent_exec() {
 
 bin_location() {
     case $OS in
-    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint)
+    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed)
         echo "/usr/bin/nextdns"
         ;;
     darwin|synology)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2037523/79312582-62f1de80-7eff-11ea-9f93-97f44c5d2ce2.png)
As seen above, printf requires an argument.
Called thru print() function without args, it mixed errors in the terminal output.  