### PR TITLE
ci: fix commit author in OpenWRT flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,10 @@ jobs:
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
 
           if [ "${{ matrix.openwrt-branch }}" == "master" ]; then 
-            export PR_TITLE="[${{ env.BACKPORT_VERSION }}] nextdns: Update to version ${{ env.VERSION }}";
+            export PR_TITLE="nextdns: Update to version $VERSION";
           else 
             BACKPORT_VERSION=$(echo ${{ matrix.openwrt-branch }} | sed 's/openwrt-//')
-            export PR_TITLE="[$BACKPORT_VERSION] nextdns: Update to version ${{ env.VERSION }}";
+            export PR_TITLE="[$BACKPORT_VERSION] nextdns: Update to version $VERSION";
           fi
 
           echo "::set-env name=OPENWRT_HASH::$OPENWRT_HASH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           export AUTHOR_NAME=$(git log -1 --format=%aN)
           export AUTHOR_EMAIL=$(git log -1 --format=%aE)
           umask 022
-          curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
+          curl -Ls https://api.github.com/repos/nextdns/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
           XZ_OPT=-7e tar --numeric-owner --owner=0 --group=0 --sort=name --mtime=$MTIME -J -C /tmp  -cf /tmp/nextdns-$VERSION.tar.xz nextdns-$VERSION 
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
-          repository: mad-it/packages
+          repository: rs/openwrt-packages
           ref: ${{ matrix.openwrt-branch }}
       - name: Rebase fork
         run: |
@@ -80,4 +80,4 @@ jobs:
           body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
           author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          # request-to-parent: true
+          request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,8 @@ jobs:
           export TAG=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
           export VERSION=${TAG:1}
           export MTIME=$(git log -1 --format='@%ct')
+          export AUTHOR_NAME=$(git log -1 --format=%aN)
+          export AUTHOR_EMAIL=$(git log -1 --format=%aE)
           umask 022
           curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
@@ -49,6 +51,8 @@ jobs:
 
           echo "::set-env name=OPENWRT_HASH::$OPENWRT_HASH"
           echo "::set-env name=VERSION::$VERSION"
+          echo "::set-env name=AUTHOR_NAME::$AUTHOR_NAME"
+          echo "::set-env name=AUTHOR_EMAIL::$AUTHOR_EMAIL"
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
@@ -70,11 +74,10 @@ jobs:
           commit-message: |
             nextdns: Update to version ${{ env.VERSION }}
 
-            Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+            Signed-off-by: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
           title: "nextdns: Update to version ${{ env.VERSION }}"
           branch: "nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}"
           body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
           # request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,13 +67,13 @@ jobs:
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
-          commit-message: "nextdns: Update to version ${{ env.VERSION }}"
+          commit-message: |
+            nextdns: Update to version ${{ env.VERSION }}
+
+            Signed-off-by: Olivier Poitrey <rs@nextdns.io>
           title: "nextdns: Update to version ${{ env.VERSION }}"
           branch: "nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}"
-          body: |
-           "Update to version ${{ env.VERSION }}"
-
-           Signed-off-by: Olivier Poitrey <rs@nextdns.io>
+          body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
           committer: "Olivier Poitrey <rs@nextdns.io>"
           author: "Olivier Poitrey <rs@nextdns.io>"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,18 +43,25 @@ jobs:
           export MTIME=$(git log -1 --format='@%ct')
           export AUTHOR_NAME=$(git log -1 --format=%aN)
           export AUTHOR_EMAIL=$(git log -1 --format=%aE)
-          export BACKPORT_VERSION=$(echo ${{ matrix.openwrt-branch }} | sed 's/openwrt-//')
+
           umask 022
           curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
           XZ_OPT=-7e tar --numeric-owner --owner=0 --group=0 --sort=name --mtime=$MTIME -J -C /tmp  -cf /tmp/nextdns-$VERSION.tar.xz nextdns-$VERSION 
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
 
+          if [ "${{ matrix.openwrt-branch }}" == "master" ]; then 
+            export PR_TITLE="[${{ env.BACKPORT_VERSION }}] nextdns: Update to version ${{ env.VERSION }}";
+          else 
+            BACKPORT_VERSION=$(echo ${{ matrix.openwrt-branch }} | sed 's/openwrt-//')
+            export PR_TITLE="[$BACKPORT_VERSION] nextdns: Update to version ${{ env.VERSION }}";
+          fi
+
           echo "::set-env name=OPENWRT_HASH::$OPENWRT_HASH"
           echo "::set-env name=VERSION::$VERSION"
           echo "::set-env name=AUTHOR_NAME::$AUTHOR_NAME"
           echo "::set-env name=AUTHOR_EMAIL::$AUTHOR_EMAIL"
-          echo "::set-env name=BACKPORT_VERSION::$BACKPORT_VERSION"
+          echo "::set-env name=PR_TITLE::$PR_TITLE"
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
@@ -69,23 +76,7 @@ jobs:
         run: |
           sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ env.VERSION }}/' net/nextdns/Makefile
           sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ env.OPENWRT_HASH }}/' net/nextdns/Makefile
-      - name: Create pull request towards OpenWRT - master
-        if:  matrix.openwrt-branch == 'master'
-        uses: peter-evans/create-pull-request@v2
-        with:
-          token: ${{ secrets.RELEASE_GH_TOKEN }}
-          commit-message: |
-            nextdns: Update to version ${{ env.VERSION }}
-
-            Signed-off-by: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          title: "nextdns: Update to version ${{ env.VERSION }}"
-          branch: nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}
-          body: Update to version ${{ env.VERSION }}
-          base: ${{ matrix.openwrt-branch }}
-          author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          # request-to-parent: true
       - name: Create pull request towards OpenWRT - ${{ matrix.openwrt-branch }}
-        if: matrix.openwrt-branch != 'master'
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
@@ -93,7 +84,7 @@ jobs:
             nextdns: Update to version ${{ env.VERSION }}
 
             Signed-off-by: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          title: "[${{ env.BACKPORT_VERSION }}] nextdns: Update to version ${{ env.VERSION }}"
+          title: ${{ env.PR_TITLE }}
           branch: nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}
           body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,11 @@ jobs:
           commit-message: |
             nextdns: Update to version ${{ env.VERSION }}
 
-            Signed-off-by: Olivier Poitrey <rs@nextdns.io>
+            Signed-off-by: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           title: "nextdns: Update to version ${{ env.VERSION }}"
           branch: "nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}"
           body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
-          committer: "Olivier Poitrey <rs@nextdns.io>"
-          author: "Olivier Poitrey <rs@nextdns.io>"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           # request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,18 @@ jobs:
         run: ./.bintray
         env:
           API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-  publishToOpenWRT:
+  OpenWRTVariables:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        openwrt-branch: ["master", "openwrt-19.07"]
+    outputs:
+      OPENWRT_HASH: ${{ steps.output.outputs.OPENWRT_HASH }}
+      VERSION: ${{ steps.output.outputs.VERSION }}
+      AUTHOR_NAME: ${{ steps.output.outputs.AUTHOR_NAME }}
+      AUTHOR_EMAIL: ${{ steps.output.outputs.AUTHOR_EMAIL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set environment variables
+      - name: Compute OpenWRT variables
+        id: output
         run: |
           export TAG=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
           export VERSION=${TAG:1}
@@ -44,19 +47,61 @@ jobs:
           export AUTHOR_NAME=$(git log -1 --format=%aN)
           export AUTHOR_EMAIL=$(git log -1 --format=%aE)
           umask 022
-          curl -Ls https://api.github.com/repos/nextdns/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
+          curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
           XZ_OPT=-7e tar --numeric-owner --owner=0 --group=0 --sort=name --mtime=$MTIME -J -C /tmp  -cf /tmp/nextdns-$VERSION.tar.xz nextdns-$VERSION 
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
 
-          echo "::set-env name=OPENWRT_HASH::$OPENWRT_HASH"
-          echo "::set-env name=VERSION::$VERSION"
-          echo "::set-env name=AUTHOR_NAME::$AUTHOR_NAME"
-          echo "::set-env name=AUTHOR_EMAIL::$AUTHOR_EMAIL"
+          echo "::set-output name=OPENWRT_HASH::$OPENWRT_HASH"
+          echo "::set-output name=VERSION::$VERSION"
+          echo "::set-output name=AUTHOR_NAME::$AUTHOR_NAME"
+          echo "::set-output name=AUTHOR_EMAIL::$AUTHOR_EMAIL"
+  publishToOpenWRT-master:
+    runs-on: ubuntu-latest
+    needs: OpenWRTVariables
+    outputs:
+      OPENWRT_MASTER_PR_NUMBER: ${{ steps.cpr.outputs.pr_number }}
+    steps:
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
-          repository: rs/openwrt-packages
+          repository: mad-it/packages
+          ref: master
+      - name: Rebase fork
+        run: |
+          git remote add upstream https://github.com/openwrt/packages.git
+          git fetch upstream
+          git reset --hard upstream/master
+      - name: Update nextdns Makefile
+        run: |
+          sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ needs.OpenWRTVariables.outputs.VERSION }}/' net/nextdns/Makefile
+          sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ needs.OpenWRTVariables.outputs.OPENWRT_HASH }}/' net/nextdns/Makefile
+      - name: Create pull request towards OpenWRT
+        id: cpr
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.RELEASE_GH_TOKEN }}
+          commit-message: |
+            nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
+
+            Signed-off-by: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
+          title: "nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}"
+          branch: nextdns-${{ needs.OpenWRTVariables.outputs.VERSION }}-master
+          body: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
+          base: master
+          author: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
+          # request-to-parent: true
+  publishToOpenWRT-backports:
+    runs-on: ubuntu-latest
+    needs: [OpenWRTVariables, publishToOpenWRT-master]
+    strategy:
+      matrix:
+        openwrt-branch: ["openwrt-19.07"]
+    steps:
+      - name: Checkout OpenWRT packages repository fork
+        uses: actions/checkout@v2
+        with:
+          repository: mad-it/packages
           ref: ${{ matrix.openwrt-branch }}
       - name: Rebase fork
         run: |
@@ -65,19 +110,22 @@ jobs:
           git reset --hard upstream/${{ matrix.openwrt-branch }}
       - name: Update nextdns Makefile
         run: |
-          sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ env.VERSION }}/' net/nextdns/Makefile
-          sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ env.OPENWRT_HASH }}/' net/nextdns/Makefile
-      - name: Create pull request towards OpenWRT - master
+          sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ needs.OpenWRTVariables.outputs.VERSION }}/' net/nextdns/Makefile
+          sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ needs.OpenWRTVariables.outputs.OPENWRT_HASH }}/' net/nextdns/Makefile
+      - name: Create pull request towards OpenWRT
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
           commit-message: |
-            nextdns: Update to version ${{ env.VERSION }}
+            nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
 
-            Signed-off-by: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          title: "nextdns: Update to version ${{ env.VERSION }}"
-          branch: nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}
-          body: Update to version ${{ env.VERSION }}
+            Signed-off-by: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
+          title: "nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}"
+          branch: nextdns-${{ needs.OpenWRTVariables.outputs.VERSION }}-${{ matrix.openwrt-branch }}
+          body: |
+            Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
+
+            PR towards master has been created #${{ needs.publishToOpenWRT-master.outputs.OPENWRT_MASTER_PR_NUMBER }}
           base: ${{ matrix.openwrt-branch }}
-          author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          request-to-parent: true
+          author: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
+          # request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           export VERSION=${TAG:1}
           export MTIME=$(git log -1 --format='@%ct')
           umask 022
-          curl -Ls https://api.github.com/repos/rs/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
+          curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
           XZ_OPT=-7e tar --numeric-owner --owner=0 --group=0 --sort=name --mtime=$MTIME -J -C /tmp  -cf /tmp/nextdns-$VERSION.tar.xz nextdns-$VERSION 
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
-          repository: rs/openwrt-packages
+          repository: mad-it/packages
           ref: ${{ matrix.openwrt-branch }}
       - name: Rebase fork
         run: |
@@ -70,6 +70,11 @@ jobs:
           commit-message: "nextdns: Update to version ${{ env.VERSION }}"
           title: "nextdns: Update to version ${{ env.VERSION }}"
           branch: "nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}"
-          body: "Update to version ${{ env.VERSION }}"
+          body: |
+           "Update to version ${{ env.VERSION }}"
+
+           Signed-off-by: Olivier Poitrey <rs@nextdns.io>
           base: ${{ matrix.openwrt-branch }}
-          request-to-parent: true
+          committer: "Olivier Poitrey <rs@nextdns.io>"
+          author: "Olivier Poitrey <rs@nextdns.io>"
+          # request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,9 @@ jobs:
           export MTIME=$(git log -1 --format='@%ct')
           export AUTHOR_NAME=$(git log -1 --format=%aN)
           export AUTHOR_EMAIL=$(git log -1 --format=%aE)
+          export BACKPORT_VERSION=$(echo ${{ matrix.openwrt-branch }} | sed 's/openwrt-//')
           umask 022
-          curl -Ls https://api.github.com/repos/nextdns/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
+          curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
           XZ_OPT=-7e tar --numeric-owner --owner=0 --group=0 --sort=name --mtime=$MTIME -J -C /tmp  -cf /tmp/nextdns-$VERSION.tar.xz nextdns-$VERSION 
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
@@ -53,10 +54,11 @@ jobs:
           echo "::set-env name=VERSION::$VERSION"
           echo "::set-env name=AUTHOR_NAME::$AUTHOR_NAME"
           echo "::set-env name=AUTHOR_EMAIL::$AUTHOR_EMAIL"
+          echo "::set-env name=BACKPORT_VERSION::$BACKPORT_VERSION"
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
-          repository: rs/openwrt-packages
+          repository: mad-it/packages
           ref: ${{ matrix.openwrt-branch }}
       - name: Rebase fork
         run: |
@@ -68,6 +70,7 @@ jobs:
           sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ env.VERSION }}/' net/nextdns/Makefile
           sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ env.OPENWRT_HASH }}/' net/nextdns/Makefile
       - name: Create pull request towards OpenWRT - master
+        if:  ${{ matrix.openwrt-branch }} == 'master'
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
@@ -80,4 +83,19 @@ jobs:
           body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
           author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          request-to-parent: true
+          # request-to-parent: true
+      - name: Create pull request towards OpenWRT - ${{ matrix.openwrt-branch }}
+        if: ${{ matrix.openwrt-branch }} != 'master'
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.RELEASE_GH_TOKEN }}
+          commit-message: |
+            nextdns: Update to version ${{ env.VERSION }}
+
+            Signed-off-by: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
+          title: "[${{ env.BACKPORT_VERSION }}] nextdns: Update to version ${{ env.VERSION }}"
+          branch: nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}
+          body: Update to version ${{ env.VERSION }}
+          base: ${{ matrix.openwrt-branch }}
+          author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
+          # request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
 
             Signed-off-by: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
           title: "nextdns: Update to version ${{ env.VERSION }}"
-          branch: "nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}"
+          branch: nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}
           body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
           author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,18 +28,15 @@ jobs:
         run: ./.bintray
         env:
           API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-  OpenWRTVariables:
+  publishToOpenWRT:
     runs-on: ubuntu-latest
-    outputs:
-      OPENWRT_HASH: ${{ steps.output.outputs.OPENWRT_HASH }}
-      VERSION: ${{ steps.output.outputs.VERSION }}
-      AUTHOR_NAME: ${{ steps.output.outputs.AUTHOR_NAME }}
-      AUTHOR_EMAIL: ${{ steps.output.outputs.AUTHOR_EMAIL }}
+    strategy:
+      matrix:
+        openwrt-branch: ["master", "openwrt-19.07"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Compute OpenWRT variables
-        id: output
+      - name: Set environment variables
         run: |
           export TAG=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
           export VERSION=${TAG:1}
@@ -47,61 +44,19 @@ jobs:
           export AUTHOR_NAME=$(git log -1 --format=%aN)
           export AUTHOR_EMAIL=$(git log -1 --format=%aE)
           umask 022
-          curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
+          curl -Ls https://api.github.com/repos/nextdns/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
           XZ_OPT=-7e tar --numeric-owner --owner=0 --group=0 --sort=name --mtime=$MTIME -J -C /tmp  -cf /tmp/nextdns-$VERSION.tar.xz nextdns-$VERSION 
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
 
-          echo "::set-output name=OPENWRT_HASH::$OPENWRT_HASH"
-          echo "::set-output name=VERSION::$VERSION"
-          echo "::set-output name=AUTHOR_NAME::$AUTHOR_NAME"
-          echo "::set-output name=AUTHOR_EMAIL::$AUTHOR_EMAIL"
-  publishToOpenWRT-master:
-    runs-on: ubuntu-latest
-    needs: OpenWRTVariables
-    outputs:
-      OPENWRT_MASTER_PR_NUMBER: ${{ steps.cpr.outputs.pr_number }}
-    steps:
+          echo "::set-env name=OPENWRT_HASH::$OPENWRT_HASH"
+          echo "::set-env name=VERSION::$VERSION"
+          echo "::set-env name=AUTHOR_NAME::$AUTHOR_NAME"
+          echo "::set-env name=AUTHOR_EMAIL::$AUTHOR_EMAIL"
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
-          repository: mad-it/packages
-          ref: master
-      - name: Rebase fork
-        run: |
-          git remote add upstream https://github.com/openwrt/packages.git
-          git fetch upstream
-          git reset --hard upstream/master
-      - name: Update nextdns Makefile
-        run: |
-          sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ needs.OpenWRTVariables.outputs.VERSION }}/' net/nextdns/Makefile
-          sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ needs.OpenWRTVariables.outputs.OPENWRT_HASH }}/' net/nextdns/Makefile
-      - name: Create pull request towards OpenWRT
-        id: cpr
-        uses: peter-evans/create-pull-request@v2
-        with:
-          token: ${{ secrets.RELEASE_GH_TOKEN }}
-          commit-message: |
-            nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
-
-            Signed-off-by: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
-          title: "nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}"
-          branch: nextdns-${{ needs.OpenWRTVariables.outputs.VERSION }}-master
-          body: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
-          base: master
-          author: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
-          # request-to-parent: true
-  publishToOpenWRT-backports:
-    runs-on: ubuntu-latest
-    needs: [OpenWRTVariables, publishToOpenWRT-master]
-    strategy:
-      matrix:
-        openwrt-branch: ["openwrt-19.07"]
-    steps:
-      - name: Checkout OpenWRT packages repository fork
-        uses: actions/checkout@v2
-        with:
-          repository: mad-it/packages
+          repository: rs/openwrt-packages
           ref: ${{ matrix.openwrt-branch }}
       - name: Rebase fork
         run: |
@@ -110,22 +65,19 @@ jobs:
           git reset --hard upstream/${{ matrix.openwrt-branch }}
       - name: Update nextdns Makefile
         run: |
-          sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ needs.OpenWRTVariables.outputs.VERSION }}/' net/nextdns/Makefile
-          sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ needs.OpenWRTVariables.outputs.OPENWRT_HASH }}/' net/nextdns/Makefile
-      - name: Create pull request towards OpenWRT
+          sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ env.VERSION }}/' net/nextdns/Makefile
+          sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ env.OPENWRT_HASH }}/' net/nextdns/Makefile
+      - name: Create pull request towards OpenWRT - master
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
           commit-message: |
-            nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
+            nextdns: Update to version ${{ env.VERSION }}
 
-            Signed-off-by: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
-          title: "nextdns: Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}"
-          branch: nextdns-${{ needs.OpenWRTVariables.outputs.VERSION }}-${{ matrix.openwrt-branch }}
-          body: |
-            Update to version ${{ needs.OpenWRTVariables.outputs.VERSION }}
-
-            PR towards master has been created #${{ needs.publishToOpenWRT-master.outputs.OPENWRT_MASTER_PR_NUMBER }}
+            Signed-off-by: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
+          title: "nextdns: Update to version ${{ env.VERSION }}"
+          branch: nextdns-${{ env.VERSION }}-${{ matrix.openwrt-branch }}
+          body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
-          author: ${{ needs.OpenWRTVariables.outputs.AUTHOR_NAME }} <${{ needs.OpenWRTVariables.outputs.AUTHOR_EMAIL }}>
-          # request-to-parent: true
+          author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
+          request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           export AUTHOR_EMAIL=$(git log -1 --format=%aE)
 
           umask 022
-          curl -Ls https://api.github.com/repos/mad-it/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
+          curl -Ls https://api.github.com/repos/nextdns/nextdns/tarball/$TAG | tar -xz --no-same-permissions -C /tmp
           mv /tmp/*nextdns* /tmp/nextdns-$VERSION
           XZ_OPT=-7e tar --numeric-owner --owner=0 --group=0 --sort=name --mtime=$MTIME -J -C /tmp  -cf /tmp/nextdns-$VERSION.tar.xz nextdns-$VERSION 
           export OPENWRT_HASH=$(sha256sum /tmp/nextdns-$VERSION.tar.xz | awk '{print $1}')
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout OpenWRT packages repository fork
         uses: actions/checkout@v2
         with:
-          repository: mad-it/packages
+          repository: rs/openwrt-packages
           ref: ${{ matrix.openwrt-branch }}
       - name: Rebase fork
         run: |
@@ -89,4 +89,4 @@ jobs:
           body: Update to version ${{ env.VERSION }}
           base: ${{ matrix.openwrt-branch }}
           author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
-          # request-to-parent: true
+          request-to-parent: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           sed -i 's/PKG_VERSION:=.*/PKG_VERSION:=${{ env.VERSION }}/' net/nextdns/Makefile
           sed -i 's/PKG_MIRROR_HASH:=.*/PKG_MIRROR_HASH:=${{ env.OPENWRT_HASH }}/' net/nextdns/Makefile
       - name: Create pull request towards OpenWRT - master
-        if:  ${{ matrix.openwrt-branch }} == 'master'
+        if:  matrix.openwrt-branch == 'master'
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
           author: ${{ env.AUTHOR_NAME }} <${{ env.AUTHOR_EMAIL }}>
           # request-to-parent: true
       - name: Create pull request towards OpenWRT - ${{ matrix.openwrt-branch }}
-        if: ${{ matrix.openwrt-branch }} != 'master'
+        if: matrix.openwrt-branch != 'master'
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}


### PR DESCRIPTION
This PR fixes the issue with checks failing in OpenWRT.

There were 2 possibilities in to solve these issues:

Option 1: Hardcode everything to `Olivier Poitrey <rs@nextdns.io>`
Option 2: Define the author based on author of the commit.

I opted for option 2 because this is more in line with the reality of the commit history.

On that note, I don't know if OpenWRT checks if the author is the same as `PKG_MAINTAINER` which is configured in the package. If they do, we might need to revisit this, because I have noticed the following commit in the commit history:
```
commit 9cdc17eb5451a979a993c7a89085a4e1f7817795
Author: Olivier Poitrey <rs@xxxxxxx.net>
Date:   Mon May 4 16:24:42 2020 -0700

Update issue templates
```

As you can see, the email(domain redacted for your privacy even though its a public git repo) is not in line with what is configured OpenWRT's `PKG_MAINTAINER`.