### PR TITLE
install.sh: always set a user-agent for api.github.com

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -892,7 +892,7 @@ get_release() {
     if [ "$NEXTDNS_VERSION" ]; then
         echo "$NEXTDNS_VERSION"
     else
-        curl="curl -s"
+        curl="curl -A curl -s"
         if [ -z "$(command -v curl 2>/dev/null)" ]; then
             curl="openssl_get"
         fi


### PR DESCRIPTION
Ref: https://developer.github.com/v3/#user-agent-required

This makes the script work in environments where user agent is disabled via `.curlrc` (or similar means.)