### PR TITLE
Proposal: Run as unprivileged user under Systemd

### DIFF
--- a/etc/systemd/system/nextdns.service
+++ b/etc/systemd/system/nextdns.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=NextDNS DNS53 to DoH proxy.
+ConditionFileIsExecutable=/usr/bin/nextdns
+After=network.target
+Before=nss-lookup.target
+Wants=nss-lookup.target
+
+[Service]
+StartLimitInterval=5
+StartLimitBurst=10
+Environment=SERVICE_RUN_MODE=1
+ExecStart=/usr/bin/nextdns run
+RestartSec=120
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/nextdns.service
+++ b/etc/systemd/system/nextdns.service
@@ -9,9 +9,14 @@ Wants=nss-lookup.target
 StartLimitInterval=5
 StartLimitBurst=10
 Environment=SERVICE_RUN_MODE=1
-ExecStart=/usr/bin/nextdns run
+ExecStart=/usr/bin/nextdns run -control /var/run/nextdns/nextdns.sock
 RestartSec=120
 LimitMEMLOCK=infinity
+Type=simple
+User=nextdns
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/sysusers.d/nexdns.conf
+++ b/etc/sysusers.d/nexdns.conf
@@ -1,0 +1,1 @@
+u nextdns - "NextDNS Service"

--- a/etc/tmpfiles.d/nextdns.conf
+++ b/etc/tmpfiles.d/nextdns.conf
@@ -1,0 +1,1 @@
+d /var/run/nextdns 0755 nextdns nextdns


### PR DESCRIPTION
This is a proposal to enable the NextDNS daemon to run as an unprivileged user under Systemd.

A few systemd specific files are provided:

- sysusers.d/nexdns.conf - creates the nextdns user
- tmpfiles.d/nextdns.conf - creates a directory under /var/run belonging to the user
- the updated service file (you can diff between the two provided commits)

I have managed to successfully run the daemon locally as unprivileged.
The only issue is with the hard-coded socket path in `config/ctl_unix.go` used by the control server.

The daemon runs but I'm unable to issue commands like `nextdns cache-stats`.
Apparently both the socket path defined in the `/etc/nextdns.conf` config is ignored, and the daemon `-control` argument is ignored.


Some sample output:

```
> ps aux|grep nextdns

nextdns    35740  0.1  0.1 1675928 18184 ?       Ssl  11:08   0:02 /usr/bin/nextdns run -control /var/run/nextdns/nextdns.sock


> journalctl -b -u nextdns

Feb 06 11:08:08 blue systemd[1]: Started NextDNS DNS53 to DoH proxy..
Feb 06 11:08:08 blue nextdns[35740]: Starting NextDNS 1.10.1/linux on localhost:53
Feb 06 11:08:08 blue nextdns[35740]: Listening on TCP/[::1]:53
Feb 06 11:08:08 blue nextdns[35740]: Listening on TCP/127.0.0.1:53
Feb 06 11:08:08 blue nextdns[35740]: Listening on UDP/[::1]:53
Feb 06 11:08:08 blue nextdns[35740]: Listening on UDP/127.0.0.1:53
Feb 06 11:08:59 blue nextdns[35740]: Connected 45.90.28.0:443 (con=27ms tls=106ms, TLS13)
Feb 06 11:08:59 blue nextdns[35740]: Connected ...:443 (con=9ms tls=11ms, TLS13)
Feb 06 11:08:59 blue nextdns[35740]: Switching endpoint: ...
```

As root:

```
# nextdns cache-stats

Error: dial unix /var/run/nextdns.sock: connect: no such file or directory
```
