### PR TITLE
Fix  problem with testing service status on the Synology init

### DIFF
--- a/host/service/synology/service.go
+++ b/host/service/synology/service.go
@@ -82,7 +82,7 @@ get_pid() {
 }
 
 is_running() {
-	test -f "$pid_file" && ps | grep -q "^ *$(get_pid) "
+	[ -f "$pid_file" ] && ps $(get_pid) > /dev/null 2>&1
 }
 
 case "$1" in


### PR DESCRIPTION
This PR fixes the Synology init script to get service status. May need more checking to ensure it works on all models, the current implementation doesn't work on some models including the DS918+ (#413 ).