### PR TITLE
Fix support for VyOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -459,7 +459,7 @@ install_type() {
     opensuse-tumbleweed|opensuse)
         echo "zypper"
         ;;
-    debian|ubuntu|elementary|raspbian|linuxmint|pop|neon|sparky)
+    debian|ubuntu|elementary|raspbian|linuxmint|pop|neon|sparky|vyos)
         echo "deb"
         ;;
     arch|manjaro)
@@ -821,7 +821,7 @@ detect_os() {
                 fi
                 echo "$dist"; return 0
                 ;;
-            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus|pop|neon|overthebox|sparky)
+            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus|pop|neon|overthebox|sparky|vyos)
                 echo "$dist"; return 0
                 ;;
             esac
@@ -905,7 +905,7 @@ silent_exec() {
 
 bin_location() {
     case $OS in
-    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus|pop|neon|sparky)
+    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse|solus|pop|neon|sparky|vyos)
         echo "/usr/bin/nextdns"
         ;;
     openwrt|overthebox)


### PR DESCRIPTION
Add `vyos` to the installer script case statements.

VyOS `/etc/os-release` `ID` was changed from `debian` to `vyos` on [Feb 23](https://github.com/vyos/vyos-build/commit/e218a757616d27a5c31a3c39a175c5e73a376f23#diff-875a9be0f0342ad3b8430148a75ebdd02afce1fadd535ad8547c244de3d9fd9dR109).

The proposed changes fix the issues detailed in #440 

Tested on `1.4-rolling-202103251004`.