### PR TITLE
Fix detection of Upstart init

### DIFF
--- a/host/service/upstart/service.go
+++ b/host/service/upstart/service.go
@@ -22,6 +22,10 @@ func New(c service.Config) (Service, error) {
 	if _, err := exec.LookPath("initctl"); err != nil {
 		return Service{}, service.ErrNotSuported
 	}
+	out, err := internal.RunOutput("initctl", "version")
+	if err != nil || !strings.Contains(out, "upstart") {
+		return Service{}, service.ErrNotSuported
+	}
 	return Service{
 		Config:           c,
 		ConfigFileStorer: service.ConfigFileStorer{File: "/etc/" + c.Name + ".conf"},


### PR DESCRIPTION
initctl binary is also present for SysV system. Debian not running
systemd would be misdetected as Upstart. The usual way to detect if
Upstart is installed and running is to query `initctl version`.

This fix has been tested on Debian 8 without systemd, Ubuntu 14 with
Upstart not running and Ubuntu 14 with Upstart running.