### PR TITLE
Fix installation when Busybox shell does not support "command"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -943,7 +943,9 @@ get_release() {
         echo "$NEXTDNS_VERSION"
     else
         for cmd in curl wget openssl true; do
-            ! command -v $cmd > /dev/null 2> /dev/null || break
+            # command is the "right" way but may be compiled out of busybox shell
+            ! command -v $cmd > /dev/null 2>&1 || break
+            ! which $cmd > /dev/null 2>&1 || break
         done
         case "$cmd" in
         curl) cmd="curl -A curl -s" ;;


### PR DESCRIPTION
The `command` builtin is optional in Busybox shell. Use `which` as it
is likely to be present as, historically, it is the most often used
method (but in POSIX). See
https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then/85250#85250.