### PR TITLE
Update the Synology init script to cater for underlying shell being Busybox

### DIFF
--- a/host/service/synology/service.go
+++ b/host/service/synology/service.go
@@ -82,7 +82,11 @@ get_pid() {
 }
 
 is_running() {
-	[ -f "$pid_file" ] && ps $(get_pid) > /dev/null 2>&1
+	if readlink /bin/ls 2>&1 | grep busybox > /dev/null ; then
+		test -f "$pid_file" && ps | grep -q "^ *$(get_pid) "
+	else
+		[ -f "$pid_file" ] && ps $(get_pid) > /dev/null 2>&1
+	fi
 }
 
 case "$1" in


### PR DESCRIPTION
Add a check to the Synology init script to identify whether we are running under Busybox, if so then use a different method to get the running pid.