### PR TITLE
Fix nextdns log command on ASUSWRT-Merlin

### DIFF
--- a/host/log_linux.go
+++ b/host/log_linux.go
@@ -12,6 +12,10 @@ func newServiceLogger(name string) (Logger, error) {
 }
 
 func ReadLog(name string) ([]byte, error) {
+	// Merlin
+	if _, err := os.Stat("/jffs/syslog.log"); err == nil {
+		return exec.Command("grep", fmt.Sprintf(` %s\(:\|\[\)`, name), "/jffs/syslog.log").Output()
+	}
 	// OpenWRT
 	if _, err := exec.LookPath("logread"); err == nil {
 		return exec.Command("logread", "-e", name).Output()
@@ -27,10 +31,6 @@ func ReadLog(name string) ([]byte, error) {
 	// Pre-systemd
 	if _, err := os.Stat("/var/log/messages"); err == nil {
 		return exec.Command("grep", fmt.Sprintf(` %s\(:\|\[\)`, name), "/var/log/messages").Output()
-	}
-	// Merlin
-	if _, err := os.Stat("/jffs/syslog.log"); err == nil {
-		return exec.Command("grep", fmt.Sprintf(` %s\(:\|\[\)`, name), "/jffs/syslog.log").Output()
 	}
 	return nil, errors.New("not supported")
 }


### PR DESCRIPTION
As of firmware version 386.1, Merlin added the Busybox logread applet, so it is in the path, but non-functional because syslogd is still writing to a file and not shared memory.

This PR checks for the /jffs/syslog.log file before checking for the logread command.

Fixes #469