### PR TITLE
proxy: limit the number of concurrent inflight requests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	BogusPriv            bool
 	UseHosts             bool
 	Timeout              time.Duration
+	MaxInflightRequests  uint
 	SetupRouter          bool
 	AutoActivate         bool
 }
@@ -145,6 +146,11 @@ func (c *Config) flagSet(cmd string) flagSet {
 	fs.BoolVar(&c.UseHosts, "use-hosts", true,
 		"Lookup /etc/hosts before sending queries to upstream resolver.")
 	fs.DurationVar(&c.Timeout, "timeout", 5*time.Second, "Maximum duration allowed for a request before failing.")
+	fs.UintVar(&c.MaxInflightRequests, "max-inflight-requests", 256,
+		"Maximum number of inflight requests handled by the proxy. No additional\n"+
+			"requests will not be answered after this threshold is met. Increasing\n"+
+			"this value can reduce latency in case of burst of requests but it can\n"+
+			"also increase significantly memory usage.")
 	fs.BoolVar(&c.SetupRouter, "setup-router", false,
 		"Automatically configure NextDNS for a router setup.\n"+
 			"Common types of router are detected to integrate gracefuly. Changes\n"+
@@ -234,6 +240,13 @@ func (fs flagSet) DurationVar(p *time.Duration, name string, value time.Duration
 		fs.flag.DurationVar(p, name, value, usage)
 	}
 	fs.storage[name] = service.ConfigDuration{Value: p, Default: value}
+}
+
+func (fs flagSet) UintVar(p *uint, name string, value uint, usage string) {
+	if fs.flag != nil {
+		fs.flag.UintVar(p, name, value, usage)
+	}
+	fs.storage[name] = service.ConfigUint{Value: p, Default: value}
 }
 
 func (fs flagSet) Var(value flag.Value, name string, usage string) {

--- a/host/service/config.go
+++ b/host/service/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -101,6 +102,31 @@ func (e ConfigDuration) String() string {
 		return ""
 	}
 	return e.Value.String()
+}
+
+type ConfigUint struct {
+	Value   *uint
+	Default uint
+}
+
+func (e ConfigUint) IsDefault() bool {
+	return e.Value == nil || *e.Value == e.Default
+}
+
+func (e ConfigUint) Set(v string) error {
+	d, err := strconv.ParseUint(v, 10, 16)
+	if err != nil {
+		return err
+	}
+	*e.Value = uint(d)
+	return nil
+}
+
+func (e ConfigUint) String() string {
+	if e.Value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d", e.Value)
 }
 
 type ConfigFileStorer struct {


### PR DESCRIPTION
With a default limit of 256 inflight requests, a latency of 3ms to
NextDNS, asking `dnsperf` to run at 100 QPS, there is no change in
latency (which is expected).

The limit can be adjusted using `-max-inflight-requests`. Ideally,
this could be tuned depending on the memory available on the system,
but it seems complex to do that portably in Go. I think 256 is a fine
limit for most systems. We could have a different default limit for
smaller archs (like mips) if we wanted to do some kind of "detection".