### PR TITLE
Make snapshot action work when we are not rs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           path: dist
   publishToDepo:
     name: Publish to Depo
-    needs: goreleaser
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Download Build Artifacts
@@ -181,7 +181,7 @@ jobs:
           AWS_BUCKET: repo.nextdns.io
   publishToOpenWRT:
     name: Publish to OpenWRT
-    needs: goreleaser
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/snapshot-push.yml
+++ b/.github/workflows/snapshot-push.yml
@@ -1,0 +1,69 @@
+name: Publish snapshot
+
+on:
+  workflow_run:
+    workflows:
+      - Snapshot
+    types:
+      - completed
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v4
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "dist"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/dist.zip', Buffer.from(download.data));
+      - run: unzip dist.zip
+      - name: Publish artifacts
+        run: |
+          NAME="$(cat NAME)"
+          rm -rf */ nextdns.rb config.yaml checksums.txt
+          for f in *; do mv $f "nextdns-snapshot${f#*SNAPSHOT}"; done
+          (
+            echo "<html>"
+            for f in *; do
+              echo "<a href=\"$f\">$f</a><br>"
+            done
+            echo "</html>"
+          ) > index.html
+          aws s3 sync --no-progress --delete \
+            --storage-class REDUCED_REDUNDANCY --acl public-read \
+            . "s3://${AWS_BUCKET}/${NAME}/"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_REPO_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_REPO_SECRET }}
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_BUCKET: snapshot.nextdns.io
+      - name: Comment Pull Request
+        uses: actions/github-script@v4
+        if: github.event.workflow_run.event == 'pull_request'
+        with:
+          script: |
+            const fs = require('fs'),
+                  issue_number = Number(fs.readFileSync('PR')),
+                  name = fs.readFileSync('NAME'));
+            github.issues.createComment({
+              issue_number: issue_number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `📷 <a href="https://snapshot.nextdns.io/${name}">Snapshot created</a>`
+            })

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - '*'
 
-concurrency: 
+concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
@@ -17,15 +17,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Get name (push)
-        if: github.event_name == 'push'
-        run: echo "NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-      - name: Get name (pull request)
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v4
-        with:
-          script: |
-            core.exportVariable('NAME', `pr-${context.issue.number}`)
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Go
@@ -39,28 +30,17 @@ jobs:
         with:
           version: latest
           args: release --rm-dist
-      - name: Publish artifacts
+      - name: Get name (push)
+        if: github.event_name == 'push'
         run: |
-          cd dist
-          rm -rf */ nextdns.rb config.yaml checksums.txt
-          for f in *; do mv $f "nextdns-snapshot${f#*SNAPSHOT}"; done
-          (echo "<html>"; for f in *; do echo "<a href=\"$f\">$f</a><br>"; done; echo "</html>") > index.html
-          aws s3 sync --no-progress --delete \
-            --storage-class REDUCED_REDUNDANCY --acl public-read . s3://${AWS_BUCKET}/${NAME}/
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.S3_REPO_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_REPO_SECRET }}
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_BUCKET: snapshot.nextdns.io
-      - name: Comment Pull Request
-        uses: actions/github-script@v4
+          echo -n ${GITHUB_REF#refs/heads/} | tr / - > dist/NAME
+      - name: Get name (pull request)
         if: github.event_name == 'pull_request'
+        run: |
+          echo -n pr-${{ github.event.number }} > dist/NAME
+          echo -n ${{ github.event.number }} > dist/PR
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
         with:
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `📷 <a href="https://snapshot.nextdns.io/${NAME}">Snapshot created</a>`
-            })
-
+          name: dist
+          path: dist/


### PR DESCRIPTION
Due to security concerns, actions running on a pull_request workflow do not have access to secrets. The workflow need to be cut in two: the untrusted part will test and build and upload the result as an artifact. The trusted part will take the artifact and upload it.

Downloading the artifact is a bit complex until actions/download-artifact is able to do that for us (see https://github.com/actions/download-artifact/issues/60). The code snippet is stolen from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.

It is a bit a pain to test as it needs to be merged in master before being able to test. I hope to get this right at the first try. Otherwise, I'll try to test in my own fork.