### PR TITLE
resolver: avoid parallel initialization of endpoints

### DIFF
--- a/resolver/endpoint/manager.go
+++ b/resolver/endpoint/manager.go
@@ -221,6 +221,7 @@ func (m *Manager) getActiveEndpoint() (*activeEnpoint, error) {
 				}
 				ae = m.activeEndpoint
 			}
+			m.activeEndpoint = ae
 		}
 		m.mu.Unlock()
 	}


### PR DESCRIPTION
On first use, an endpoint need to be initialized by testing it. When
several requests are processed while no endpoint has finished
initializing, additional endpoints are instantiated and tested,
leading to parallel execution of all the tests until a stable endpoint
is found.

Record the initialization endpoint as the active endpoint once it has
been built to avoid this. The endpoint still needs to be tested but
this is done under a lock to avoid parallelism. Moreover, once the
final endpoint is selected, the active endpoint is replaced by it.

The fix seems simple but it is a bit difficult to navigate in the
code. I was going to isolate the whole endpoint selection/testing into
a dedicated goroutine that would provide the active endpoint by
message passing, but this seems quite a risky change.