### PR TITLE
github: fix SHA reference when building snapshots

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,13 +28,13 @@ jobs:
         if: github.event_name == 'push'
         run: |
           echo -n ${GITHUB_REF#refs/heads/} | tr / - > dist/NAME
-          echo -n ${GITHUB_SHA} > dist/SHA
+          echo -n $(git rev-parse HEAD) > dist/SHA
       - name: Get name (pull request)
         if: github.event_name == 'pull_request'
         run: |
           echo -n pr-${{ github.event.number }} > dist/NAME
           echo -n ${{ github.event.number }} > dist/PR
-          echo -n ${GITHUB_SHA} > dist/SHA
+          echo -n $(git rev-parse HEAD) > dist/SHA
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
`GITHUB_SHA` is the reference to the merge commit of the pull request.
To get the HEAD sha, we need to use
`github.event.pull_request.head.sha`. As we have a checkout, just use
rev-parse which works if we have a PR or not.