### PR TITLE
github: fix (again) SHA reference for snapshot

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,13 +28,13 @@ jobs:
         if: github.event_name == 'push'
         run: |
           echo -n ${GITHUB_REF#refs/heads/} | tr / - > dist/NAME
-          echo -n $(git rev-parse HEAD) > dist/SHA
+          echo -n ${GITHUB_SHA} > dist/SHA
       - name: Get name (pull request)
         if: github.event_name == 'pull_request'
         run: |
           echo -n pr-${{ github.event.number }} > dist/NAME
           echo -n ${{ github.event.number }} > dist/PR
-          echo -n $(git rev-parse HEAD) > dist/SHA
+          echo -n ${{ github.event.pull_request.head.sha }} > dist/SHA
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
On a pull request, the checkout tree is also a merged tree. So, use
`github.event.pull_request.head.sha` for pull request and keep
GTIHUB_SHA for master.