### PR TITLE
install: normalize umask value when installing

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1089,4 +1089,5 @@ openssl_get() {
         openssl s_client -quiet -connect "$host:443" 2>/dev/null
 }
 
+umask 0022
 main


### PR DESCRIPTION
If user's umask is 0077, some files may be installed and readable as
root only. apt is running signature check as an unprivileged user and
therefore needs the GPG key to be world-readable. We may run into
other similar issues in the future, so it seems better to set umask to
0022 instead of trying to fix permissions everywhere.

Fix #595.