### PR TITLE
Revert "Switch to go 1.17"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.16.5"
+          go-version: "1.16.10"
       - name: Test
         run: go test ./...
       - name: Run GoReleaser

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.17.3"
+          go-version: "1.16.5"
       - name: Test
         run: go test ./...
       - name: Run GoReleaser

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.16.5"
+          go-version: "1.16.10"
       - name: Test
         run: go test ./...
       - name: Run GoReleaser

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: "1.17.3"
+          go-version: "1.16.5"
       - name: Test
         run: go test ./...
       - name: Run GoReleaser

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17.3
+        go-version: 1.16.5
 
     - name: Check out code
       uses: actions/checkout@v1

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -36,9 +36,3 @@ jobs:
 
     - name: Run staticcheck (darwin/amd64)
       run: "GOOS=darwin GOARCH=amd64 staticcheck ./..."
-
-    - name: Run staticcheck (windows/amd64)
-      run: "GOOS=windows GOARCH=amd64 staticcheck ./..."
-
-    - name: Run staticcheck (windows/386)
-      run: "GOOS=windows GOARCH=386 staticcheck ./..."

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.16.5
+        go-version: 1.16.10
 
     - name: Check out code
       uses: actions/checkout@v1


### PR DESCRIPTION
This reverts commit fe5e5b4ef8af18d75263cc68d215e617cbba316f. We
switch back to 1.16.5 just for testing. It was known to work with
1.35.0. If it works, we need to try 1.16.10 then.