### PR TITLE
github: use GoReleaser v0.182.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v0.182.1
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v0.182.1
           args: release --snapshot --rm-dist
       - name: Get name (push)
         if: github.event_name == 'push'


### PR DESCRIPTION
It was the one used to build v1.37.3 which mapped armhf to ARMv6.
v1.37.4 is using GoReleaser v1.0.0 which maps armhf to ARMv7. This is
a workaround until we understand what happens.