### PR TITLE
Proposal: Bump GoReleaser from v0.182.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.182.1
+          version: v1.1.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v1.1.0
+          version: v0.184.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.182.1
+          version: v1.1.0
           args: release --snapshot --rm-dist
       - name: Get name (push)
         if: github.event_name == 'push'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v1.1.0
+          version: v0.184.0
           args: release --snapshot --rm-dist
       - name: Get name (push)
         if: github.event_name == 'push'


### PR DESCRIPTION
### Description

In Homebrew, `bottle :unneeded` has been deprecated.
[#11239 - formula_auditor: don't allow bottle :unneeded in core.](https://github.com/Homebrew/brew/pull/11239)

The aforementioned issue has been addressed since GoReleaser 0.183.0, and can be resolved by upgrading.