### PR TITLE
release: use an armored key for RPM repositories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
           enabled=1
           gpgcheck=0
           repo_gpgcheck=1
-          gpgkey=https://repo.nextdns.io/nextdns.gpg
+          gpgkey=https://repo.nextdns.io/nextdns-armored.gpg
           EOF
           echo "::endgroup::"
           echo "::group::Create APK index files"
@@ -163,6 +163,7 @@ jobs:
           cd dist/r
           echo "$GPG_KEY" | gpg --import
           gpg --export > nextdns.gpg
+          gpg --export --armor > nextdns-armored.gpg
           echo "$REPO_KEY" > /tmp/nextdns
           openssl rsa -in /tmp/nextdns -pubout > nextdns.pub
           echo "::endgroup::"


### PR DESCRIPTION
For Debian repositories, the key needs to *not* be armored as this is
only supported since APT 1.4 (so Debian Stretch and Ubuntu Trusty
needs a non-armored key).

As reported on #558, on RPM distributions, the key is expected to be
armored and some implementations only work with an armored key.

So, we generate both key formats, we keep `nextdns.gpg` for Debian and
we use `nextdns-armored.gpg` for RPM.

Fix #558.