### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -29,7 +28,7 @@ func cfg(args []string) error {
 	case "edit":
 		var c config.Config
 		c.Parse("nextdns config edit", nil, true)
-		tmp, err := ioutil.TempFile("", "")
+		tmp, err := os.CreateTemp("", "")
 		if err != nil {
 			return err
 		}

--- a/ctl/internal/winio/backup.go
+++ b/ctl/internal/winio/backup.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"syscall"
@@ -82,7 +81,7 @@ func (r *BackupStreamReader) Next() (*BackupHeader, error) {
 				r.bytesLeft = 0
 			}
 		}
-		if _, err := io.Copy(ioutil.Discard, r); err != nil {
+		if _, err := io.Copy(io.Discard, r); err != nil {
 			return nil, err
 		}
 	}

--- a/ctl/internal/winio/backup_test.go
+++ b/ctl/internal/winio/backup_test.go
@@ -4,7 +4,6 @@ package winio
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"syscall"
 	"testing"
@@ -13,7 +12,7 @@ import (
 var testFileName string
 
 func TestMain(m *testing.M) {
-	f, err := ioutil.TempFile("", "tmp")
+	f, err := os.CreateTemp("", "tmp")
 	if err != nil {
 		panic(err)
 	}
@@ -61,7 +60,7 @@ func TestBackupRead(t *testing.T) {
 	defer f.Close()
 	r := NewBackupFileReader(f, false)
 	defer r.Close()
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +103,7 @@ func TestBackupStreamRead(t *testing.T) {
 			if hdr.Name != "" {
 				t.Fatalf("unexpected name %s", hdr.Name)
 			}
-			b, err := ioutil.ReadAll(br)
+			b, err := io.ReadAll(br)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -119,7 +118,7 @@ func TestBackupStreamRead(t *testing.T) {
 			if hdr.Name != ":ads.txt:$DATA" {
 				t.Fatalf("incorrect name %s", hdr.Name)
 			}
-			b, err := ioutil.ReadAll(br)
+			b, err := io.ReadAll(br)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -175,7 +174,7 @@ func TestBackupStreamWrite(t *testing.T) {
 
 	f.Close()
 
-	b, err := ioutil.ReadFile(testFileName)
+	b, err := os.ReadFile(testFileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +182,7 @@ func TestBackupStreamWrite(t *testing.T) {
 		t.Fatalf("wrong data %v", b)
 	}
 
-	b, err = ioutil.ReadFile(testFileName + ":ads.txt")
+	b, err = os.ReadFile(testFileName + ":ads.txt")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ctl/internal/winio/ea_test.go
+++ b/ctl/internal/winio/ea_test.go
@@ -3,7 +3,6 @@
 package winio
 
 import (
-	"io/ioutil"
 	"os"
 	"reflect"
 	"syscall"
@@ -75,7 +74,7 @@ func Test_NilEasEncodeAndDecodeAsNil(t *testing.T) {
 
 // Test_SetFileEa makes sure that the test buffer is actually parsable by NtSetEaFile.
 func Test_SetFileEa(t *testing.T) {
-	f, err := ioutil.TempFile("", "winio")
+	f, err := os.CreateTemp("", "winio")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ctl/internal/winio/fileinfo_test.go
+++ b/ctl/internal/winio/fileinfo_test.go
@@ -3,7 +3,6 @@
 package winio
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -44,7 +43,7 @@ func checkFileStandardInfo(t *testing.T, current, expected *FileStandardInfo) {
 }
 
 func TestGetFileStandardInfo_File(t *testing.T) {
-	f, err := ioutil.TempFile("", "tst")
+	f, err := os.CreateTemp("", "tst")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,11 +105,7 @@ func TestGetFileStandardInfo_File(t *testing.T) {
 }
 
 func TestGetFileStandardInfo_Directory(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "tst")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// os.Open returns the Search Handle, not the Directory Handle
 	// See https://github.com/golang/go/issues/13738

--- a/host/dns_bsd.go
+++ b/host/dns_bsd.go
@@ -5,7 +5,6 @@ package host
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -160,7 +159,7 @@ func setupResolvconfConf() error {
 				return err
 			}
 			// If file did not exist, create an empty file.
-			ioutil.WriteFile(resolvconfBackupFile, nil, 0644)
+			os.WriteFile(resolvconfBackupFile, nil, 0644)
 		}
 	}
 

--- a/host/dns_linux.go
+++ b/host/dns_linux.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -37,7 +36,7 @@ func DNS() []string {
 		func() []string {
 			var dns []string
 			const leaseDir = "/run/systemd/netif/leases"
-			if leases, err := ioutil.ReadDir(leaseDir); err == nil {
+			if leases, err := os.ReadDir(leaseDir); err == nil {
 				for _, lease := range leases {
 					if lease.IsDir() || strings.HasPrefix(lease.Name(), ".") {
 						continue
@@ -179,7 +178,7 @@ func disableNetworkManagerResolver() error {
 	}
 
 	// Disable resolv.conf management by NetworkManager
-	if err := ioutil.WriteFile(networkManagerFile, []byte("[main]\ndns=none\n"), 0644); err != nil {
+	if err := os.WriteFile(networkManagerFile, []byte("[main]\ndns=none\n"), 0644); err != nil {
 		return err
 	}
 

--- a/host/service/bsd/service.go
+++ b/host/service/bsd/service.go
@@ -4,7 +4,6 @@ package bsd
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"runtime"
@@ -39,7 +38,7 @@ func New(c service.Config) (Service, error) {
 
 func rcDaemonPath(name string) string {
 	if runtime.GOOS == "freebsd" {
-		if b, err := ioutil.ReadFile("/etc/platform"); err == nil && bytes.HasPrefix(b, []byte("pfSense")) {
+		if b, err := os.ReadFile("/etc/platform"); err == nil && bytes.HasPrefix(b, []byte("pfSense")) {
 			// https://docs.netgate.com/pfsense/en/latest/development/executing-commands-at-boot-time.html
 			return "/usr/local/etc/rc.d/" + name + ".sh"
 		}

--- a/host/service/merlin/service.go
+++ b/host/service/merlin/service.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -123,7 +122,7 @@ func excludeLine(file, line string) (found bool, out []byte, err error) {
 func addLine(file, line string) error {
 	found, _, err := excludeLine(file, line)
 	if os.IsNotExist(err) {
-		return ioutil.WriteFile(file, []byte("#!/bin/sh\n"+line+"\n"), 0755)
+		return os.WriteFile(file, []byte("#!/bin/sh\n"+line+"\n"), 0755)
 	}
 	if err != nil {
 		return err
@@ -131,7 +130,7 @@ func addLine(file, line string) error {
 	if found {
 		return service.ErrAlreadyInstalled
 	}
-	b, err := ioutil.ReadFile(file)
+	b, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
@@ -164,7 +163,7 @@ func addLine(file, line string) error {
 	}
 	if firstLine {
 		// Empty file
-		return ioutil.WriteFile(file, []byte("#!/bin/sh\n"+line+"\n"), 0755)
+		return os.WriteFile(file, []byte("#!/bin/sh\n"+line+"\n"), 0755)
 	}
 	return err
 }
@@ -180,7 +179,7 @@ func removeLine(file, line string) error {
 	if bytes.Equal(bytes.TrimSpace(out), []byte("#!/bin/sh")) {
 		return os.Remove(file)
 	}
-	return ioutil.WriteFile(file, out, 0755)
+	return os.WriteFile(file, out, 0755)
 }
 
 var tmpl = `#!/bin/sh

--- a/host/service/openrc/service.go
+++ b/host/service/openrc/service.go
@@ -3,7 +3,6 @@
 package openrc
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -18,7 +17,7 @@ type Service struct {
 }
 
 func New(c service.Config) (Service, error) {
-	if b, err := ioutil.ReadFile("/proc/1/comm"); err != nil || string(b) != "init\n" {
+	if b, err := os.ReadFile("/proc/1/comm"); err != nil || string(b) != "init\n" {
 		return Service{}, service.ErrNotSupported
 	}
 	if _, err := os.Stat("/sbin/openrc-run"); err != nil {

--- a/host/service/procd/service.go
+++ b/host/service/procd/service.go
@@ -5,7 +5,6 @@ package procd
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -72,7 +71,7 @@ func (s Service) Status() (service.Status, error) {
 	if _, err := os.Stat(s.Path); os.IsNotExist(err) {
 		return service.StatusNotInstalled, nil
 	}
-	b, err := ioutil.ReadFile("/var/run/" + s.Name + ".pid")
+	b, err := os.ReadFile("/var/run/" + s.Name + ".pid")
 	if err != nil {
 		if os.IsNotExist(err) {
 			return service.StatusStopped, nil
@@ -107,7 +106,7 @@ func (s Service) SaveConfig(c map[string]service.ConfigEntry) error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-		if err := ioutil.WriteFile(cp, []byte{}, 0644); err != nil {
+		if err := os.WriteFile(cp, []byte{}, 0644); err != nil {
 			return err
 		}
 		if _, err := uci("set", s.Name+".main="+s.Name); err != nil {

--- a/host/service/runit/service.go
+++ b/host/service/runit/service.go
@@ -5,7 +5,6 @@ package runit
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -20,7 +19,7 @@ type Service struct {
 }
 
 func New(c service.Config) (Service, error) {
-	if b, _ := ioutil.ReadFile("/proc/1/comm"); !bytes.Equal(b, []byte("runit\n")) {
+	if b, _ := os.ReadFile("/proc/1/comm"); !bytes.Equal(b, []byte("runit\n")) {
 		return Service{}, service.ErrNotSupported
 	}
 

--- a/host/service/systemd/service.go
+++ b/host/service/systemd/service.go
@@ -5,7 +5,6 @@ package systemd
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -20,7 +19,7 @@ type Service struct {
 }
 
 func New(c service.Config) (Service, error) {
-	if b, _ := ioutil.ReadFile("/proc/1/comm"); !bytes.Equal(b, []byte("systemd\n")) {
+	if b, _ := os.ReadFile("/proc/1/comm"); !bytes.Equal(b, []byte("systemd\n")) {
 		return Service{}, service.ErrNotSupported
 	}
 	return Service{

--- a/host/service/ubios/service.go
+++ b/host/service/ubios/service.go
@@ -11,7 +11,6 @@ package ubios
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -61,7 +60,7 @@ func isContainerized() (bool, error) {
 }
 
 func (s Service) Install() error {
-	if err := ioutil.WriteFile("/data/nextdns", script, 0755); err != nil {
+	if err := os.WriteFile("/data/nextdns", script, 0755); err != nil {
 		return err
 	}
 	if err := internal.CreateWithTemplate(s.Path, tmpl, 0644, s.Config); err != nil {

--- a/router/merlin/setup.go
+++ b/router/merlin/setup.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -82,7 +81,7 @@ func (r *Router) Setup() error {
 func (r *Router) Restore() error {
 	var err error
 	if r.CurrentPostConf != "" {
-		err = ioutil.WriteFile(r.DNSMasqPath, []byte(r.CurrentPostConf), 0755)
+		err = os.WriteFile(r.DNSMasqPath, []byte(r.CurrentPostConf), 0755)
 	} else {
 		err = os.Remove(r.DNSMasqPath)
 		if os.IsNotExist(err) {

--- a/router/synology/setup.go
+++ b/router/synology/setup.go
@@ -3,7 +3,6 @@ package synology
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -33,7 +32,7 @@ func New() (*Router, bool) {
 }
 
 func (r *Router) Configure(c *config.Config) error {
-	if b, err := ioutil.ReadFile("/etc/dhcpd/dhcpd.info"); err != nil || !bytes.HasPrefix(b, []byte(`enable="yes"`)) {
+	if b, err := os.ReadFile("/etc/dhcpd/dhcpd.info"); err != nil || !bytes.HasPrefix(b, []byte(`enable="yes"`)) {
 		// DHCP is disabled, listen on 53 directly
 		c.Listens = []string{":53"}
 		r.disabled = true
@@ -61,7 +60,7 @@ func (r *Router) setupDNSMasq() error {
 		return err
 	}
 	infoFile := strings.Replace(r.DNSMasqPath, ".conf", ".info", 1)
-	if err := ioutil.WriteFile(infoFile, []byte(`enable="yes"`), 0644); err != nil {
+	if err := os.WriteFile(infoFile, []byte(`enable="yes"`), 0644); err != nil {
 		return err
 	}
 	return restartDNSMasq()


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.