### PR TITLE
release: use centos:8 image but modify repo list to use vault.centos.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,8 +128,13 @@ jobs:
           (
             cd r/rpm
             # No createrepo available in Ubuntu 20.04
-            docker run --rm -w $PWD -v $PWD:$PWD redhat/ubi8:latest \
-              sh -c "yum install -y createrepo && createrepo . && chown -R $(id -u):$(id -g) ."
+            docker run --rm -w $PWD -v $PWD:$PWD centos:8 \
+              sh -c "sed -i -e 's,^mirrorlist,#mirrorlist,' \
+                            -e 's,^#baseurl,baseurl,' \
+                            -e 's,mirror.centos.org,vault.centos.org,' /etc/yum.repos.d/CentOS-* &&
+                     yum install -y createrepo &&
+                     createrepo . &&
+                     chown -R $(id -u):$(id -g) ."
           )
           cat <<EOF > r/nextdns.repo
           [nextdns]


### PR DESCRIPTION
CentOS 8 is out of support since end of 2021 and the repositories have
been moved to vault.centos.org. The Docker images have not been
updated. We patch the repository definitions to use vault.centos.org.

An alternative would be to use Fedora as a base instead, but it seems
safer to use CentOS 8 since it works and we know the repositories
created by the version of createrepo is CentOS work.