### PR TITLE
Update Go version in Dockerfile to match `.github/workflows/release.yml`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:golang AS xgo
 
-FROM --platform=$BUILDPLATFORM golang:1.14.2-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.16.10-alpine AS build
 
 ENV CGO_ENABLED=0
 COPY --from=xgo / /


### PR DESCRIPTION
They're inconsistent currently.

Reference:
https://github.com/nextdns/nextdns/blob/v1.37.11/.github/workflows/release.yml#L18