### PR TITLE
Fix Conditional Matching

### DIFF
--- a/config/id.go
+++ b/config/id.go
@@ -35,25 +35,26 @@ func newConfig(v string) (config, error) {
 	return c, nil
 }
 
-// Match resturns true if the rule matches ip and mac.
+// Match returns true if the rule matches ip and mac.
 func (c config) Match(ip net.IP, mac net.HardwareAddr) bool {
-	if c.Prefix != nil {
-		if ip == nil {
-			return false
-		}
-		if !c.Prefix.Contains(ip) {
-			return false
-		}
-	}
-	if c.MAC != nil {
-		if mac == nil {
-			return false
-		}
-		if !bytes.Equal(c.MAC, mac) {
-			return false
-		}
-	}
-	return true
+  
+        if c.Prefix != nil {
+                if ip != nil {               
+ 	               if c.Prefix.Contains(ip) {
+      	                  return true
+            	    }
+		    }
+        }
+        if len(c.MAC) > 0 {
+             if len(mac) > 0 {
+                if bytes.Equal(c.MAC, mac) {
+                        return true
+                }
+             }
+        }
+
+        return false
+
 }
 
 func (c config) String() string {

--- a/config/id.go
+++ b/config/id.go
@@ -71,13 +71,22 @@ func (c config) String() string {
 type Configs []config
 
 // Get returns the configuration matching the ip and mac conditions.
-func (cs *Configs) Get(ip net.IP, mac net.HardwareAddr) string {
-	for _, c := range *cs {
+func (cs *Configs) Get(ip net.IP, mac net.HardwareAddr) string {	
+        var defConfig string
+        for _, c := range *cs {
 		if c.Match(ip, mac) {
 			return c.Config
 		}
+
+                if(c.Prefix == nil) {
+                	if(len(c.MAC) ==0) {
+				defConfig = c.Config
+			}          
+		}  
 	}
-	return ""
+
+        
+	return defConfig
 }
 
 // String is the method to format the flag's value


### PR DESCRIPTION
As raised in issue #681 the matching was not working for conditional IDs.

The issue appears to be that as the logic defaults to true (presumably to get the default config) the method almost always returned true for the default configuration before doing any other matching as the config had the default ID as the first item. Both conditions for Prefix and MAC would not trigger a false on this entry and it would pass through.

The test for MAC would also not match as it was never nil so that false exit would not occur. 

I inverted the logic to make the method return false if there are no correct matches to the query IP and MAC. This means the caller needs to identify the default and use that if there is no match rather than relying on the true fal-through.
