### PR TITLE
Update install.sh to support installation on gentoo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -584,6 +584,9 @@ install_type() {
     ubios)
         echo "ubios"
         ;;
+    gentoo)
+        echo "bin"
+        ;;
     void)
         # TODO: pkg for xbps
         echo "bin"
@@ -890,7 +893,7 @@ detect_os() {
                 fi
                 echo "$dist"; return 0
                 ;;
-            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse-leap|opensuse|solus|pop|neon|overthebox|sparky|vyos|void|alpine|Deepin)
+            debian|ubuntu|elementary|raspbian|centos|fedora|rhel|arch|manjaro|openwrt|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse-leap|opensuse|solus|pop|neon|overthebox|sparky|vyos|void|alpine|Deepin|gentoo)
                 echo "$dist"; return 0
                 ;;
             esac
@@ -988,7 +991,7 @@ silent_exec() {
 
 bin_location() {
     case $OS in
-    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse-leap|opensuse|solus|pop|neon|sparky|vyos|void|alpine|Deepin)
+    centos|fedora|rhel|debian|ubuntu|elementary|raspbian|arch|manjaro|clear-linux-os|linuxmint|opensuse-tumbleweed|opensuse-leap|opensuse|solus|pop|neon|sparky|vyos|void|alpine|Deepin|gentoo)
         echo "/usr/bin/nextdns"
         ;;
     openwrt|overthebox)


### PR DESCRIPTION
Per #564, allows installation on systemd-based gentoo systems. This is untested on openrc-based gentoo installations.

For systemd-based installations you may need to stop and disable the systemd-resolved service prior to installation.