### PR TITLE
Move GPG key file for Debian in /etc/apt/keyrings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Debian/RPM/APK repositories
         # Manually build unsigned Debian, RPM and APK repositories
         # For Debian (the key needs to be *not* armored):
-        #   deb [signed-by=/usr/share/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main
+        #   deb [signed-by=/etc/apt/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main
         # For yum:
         #   yum-config-manager --add-repo https://repo.nextdns.io/nextdns.repo
         # For zypper:

--- a/.goreleaser/deb/postinst
+++ b/.goreleaser/deb/postinst
@@ -6,11 +6,12 @@ if [ -f $repo ] \
        && grep -qE '(nextdns.io/repo|dl.bintray.com)' $repo; then
     cat <<EOF > $repo
 # Added for NextDNS
-deb [signed-by=/usr/share/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main
+deb [signed-by=/etc/apt/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main
 EOF
-    curl -sL https://repo.nextdns.io/nextdns.gpg > /usr/share/keyrings/nextdns.gpg
+    mkdir -p /etc/apt/keyrings
+    curl -sL https://repo.nextdns.io/nextdns.gpg > /etc/apt/keyrings/nextdns.gpg
     if ! dpkg --compare-versions $(dpkg-query --showformat='${Version}' --show apt) ge 1.1; then
-        ln -sf /usr/share/keyrings/nextdns.gpg /etc/apt/trusted.gpg.d/.
+        ln -sf /etc/apt/keyrings/nextdns.gpg /etc/apt/trusted.gpg.d/.
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -279,12 +279,13 @@ install_deb() {
 
     # Fallback on curl, some debian based distrib don't have wget while debian
     # doesn't have curl by default.
-    ( asroot wget -qO /usr/share/keyrings/nextdns.gpg https://repo.nextdns.io/nextdns.gpg ||
-      asroot curl -sfL https://repo.nextdns.io/nextdns.gpg -o /usr/share/keyrings/nextdns.gpg ) &&
-        asroot chmod 0644 /usr/share/keyrings/nextdns.gpg &&
-        asroot sh -c 'echo "deb [signed-by=/usr/share/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main" > /etc/apt/sources.list.d/nextdns.list' &&
+    asroot mkdir -p /etc/apt/keyrings
+    ( asroot wget -qO /etc/apt/keyrings/nextdns.gpg https://repo.nextdns.io/nextdns.gpg ||
+      asroot curl -sfL https://repo.nextdns.io/nextdns.gpg -o /etc/apt/keyrings/nextdns.gpg ) &&
+        asroot chmod 0644 /etc/apt/keyrings/nextdns.gpg &&
+        asroot sh -c 'echo "deb [signed-by=/etc/apt/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main" > /etc/apt/sources.list.d/nextdns.list' &&
         (dpkg --compare-versions $(dpkg-query --showformat='${Version}' --show apt) ge 1.1 ||
-         asroot ln -s /usr/share/keyrings/nextdns.gpg /etc/apt/trusted.gpg.d/.) &&
+         asroot ln -s /etc/apt/keyrings/nextdns.gpg /etc/apt/trusted.gpg.d/.) &&
         (test "$OS" = "debian" && asroot apt-get -y install apt-transport-https || true) &&
         asroot apt-get update &&
         asroot apt-get install -y nextdns
@@ -464,11 +465,12 @@ uninstall_opnsense() {
 }
 
 ubios_install_source() {
-    echo "deb [signed-by=/usr/share/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main" > /data/nextdns.list
+    echo "deb [signed-by=/etc/apt/keyrings/nextdns.gpg] https://repo.nextdns.io/deb stable main" > /data/nextdns.list
     podman exec unifi-os mv /data/nextdns.list /etc/apt/sources.list.d/nextdns.list
     rm -f /tmp/nextdns.list
     podman exec unifi-os apt-get install -y gnupg1 curl
-    podman exec unifi-os curl -sfL https://repo.nextdns.io/nextdns.gpg -o /usr/share/keyrings/nextdns.gpg
+    podman exec unifi-os mkdir -p /etc/apt/keyrings/
+    podman exec unifi-os curl -sfL https://repo.nextdns.io/nextdns.gpg -o /etc/apt/keyrings/nextdns.gpg
     podman exec unifi-os apt-get update -o Dir::Etc::sourcelist="sources.list.d/nextdns.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
 }
 


### PR DESCRIPTION
Maybe it would help with failed upgrades for Unifi as users are reporting the file to disappear when placed in /usr/share/keyrings. We apply the change for all Debian-derivative to avoid confusion. /etc/apt/keyrings may even be a better location because /usr/share/keyrings should only contain files installed from the package manager.

May fix #755