### PR TITLE
discovery: add fedora/centos/rhel dnsmasq lease location

### DIFF
--- a/discovery/dhcp.go
+++ b/discovery/dhcp.go
@@ -24,6 +24,7 @@ var leaseFiles = []leaseFile{
 	{"/etc/dhcpd/dhcpd.conf.leases", "dnsmasq"},
 	{"/var/run/dnsmasq-dhcp.leases", "dnsmasq"},
 	{"/config/dhcpd.leases", "dnsmasq"},
+	{"/var/lib/dnsmasq/dhcp.leases", "dnsmasq"},
 }
 
 type DHCP struct {


### PR DESCRIPTION
Fedora and it's decendants (CentOS and then RHEL) override the default location for the dnsmasq.leases file from `/var/lib/misc/dnsmasq.leases` to `/var/lib/dnsmasq/dnsmasq.leases`.

This adds it to the list.

See the upstream patch on this change:
https://src.fedoraproject.org/rpms/dnsmasq/blob/rawhide/f/dnsmasq-2.81-configuration.patch#_79