### PR TITLE
workflow: update go to 1.19.5, codeql to v2, goreleaser to v4

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: v0.184.0
+          version: v1.14.1
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_GH_TOKEN }}
@@ -215,7 +215,7 @@ jobs:
         openwrt-branch: ["master", "openwrt-21.02", "openwrt-22.03"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set environment variables
         run: |
           TAG=$(echo $GITHUB_REF | sed 's/refs\/tags\///')
@@ -240,7 +240,7 @@ jobs:
           echo "AUTHOR_EMAIL=$AUTHOR_EMAIL" >> $GITHUB_ENV
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_ENV
       - name: Checkout OpenWRT packages repository fork
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: openwrt/packages
           ref: ${{ matrix.openwrt-branch }}
@@ -257,7 +257,7 @@ jobs:
           sed -i 's!PKG_SOURCE_URL:=.*!PKG_SOURCE_URL:=https://codeload.github.com/nextdns/nextdns/tar.gz/v$(PKG_VERSION)?!' net/nextdns/Makefile
           sed -i 's/PKG_.*HASH:=.*/PKG_HASH:=${{ env.OPENWRT_HASH }}/' net/nextdns/Makefile
       - name: Create pull request towards OpenWRT - ${{ matrix.openwrt-branch }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.RELEASE_GH_TOKEN }}
           commit-message: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Test
         run: go test ./...
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: v0.184.0
           args: release --rm-dist

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.18.1"
+          go-version: "1.19.5"
       - name: Test
         run: go test ./...
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           version: v0.184.0
           args: release --snapshot --rm-dist
@@ -36,7 +36,7 @@ jobs:
           echo -n ${{ github.event.number }} > dist/PR
           echo -n ${{ github.event.pull_request.head.sha }} > dist/SHA
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: v0.184.0
+          version: v1.14.1
           args: release --snapshot --rm-dist
       - name: Get name (push)
         if: github.event_name == 'push'

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19.1
+        go-version: 1.19.5
 
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Run go vet
       run: go vet ./...


### PR DESCRIPTION
Thanks for merging my last pull request. I realized there was much more to update when I checked it out right now. This updates almost all actions that have actions and go to 1.19.5 where it isnt