### PR TITLE
Ubiquiti dream machine multiple interface ipv6 improvements

### DIFF
--- a/router/ubios/setup.go
+++ b/router/ubios/setup.go
@@ -143,7 +143,7 @@ func (r *Router) Setup() error {
 				continue
 			}
 			if err := r.run(
-				"ip6tables -t nat -I PREROUTING 1 -m set --match-set UBIOS6ADDRv6_" + iface + " dst",
+				"ip6tables -t nat -I PREROUTING 1 -m set --match-set UBIOS6ADDRv6_" + iface + " dst -j NEXTDNS",
 			); err != nil {
 				return err
 			}
@@ -185,7 +185,7 @@ func (r *Router) Restore() error {
 				continue
 			}
 			if err := r.run(
-				"ip6tables -t nat -D PREROUTING -m set --match-set UBIOS6ADDRv6_" + iface + " dst",
+				"ip6tables -t nat -D PREROUTING -m set --match-set UBIOS6ADDRv6_" + iface + " dst -j NEXTDNS",
 			); err != nil {
 				return err
 			}

--- a/router/ubios/setup.go
+++ b/router/ubios/setup.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/nextdns/nextdns/config"
@@ -143,13 +142,8 @@ func (r *Router) Setup() error {
 			if iface == "br0" {
 				continue
 			}
-			polID, err := strconv.Atoi(strings.TrimPrefix(iface, "br"))
-			if err != nil {
-				return err
-			}
-			cmd := fmt.Sprintf("ip6tables -t nat -I PREROUTING %d -m set --match-set UBIOS6ADDRv6_%s dst", polID+1, iface)
 			if err := r.run(
-				cmd,
+				"ip6tables -t nat -I PREROUTING 1 -m set --match-set UBIOS6ADDRv6_" + iface + " dst",
 			); err != nil {
 				return err
 			}
@@ -190,9 +184,8 @@ func (r *Router) Restore() error {
 			if iface == "br0" {
 				continue
 			}
-			cmd := fmt.Sprintf("ip6tables -t nat -D PREROUTING -m set --match-set UBIOS6ADDRv6_%s dst", iface)
 			if err := r.run(
-				cmd,
+				"ip6tables -t nat -D PREROUTING -m set --match-set UBIOS6ADDRv6_" + iface + " dst",
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
Currently the integration for Ubiquiti dream machines will only support the first bridging interface `br0` as seen on [line 107 of ubios/setup.go](https://github.com/nextdns/nextdns/blob/master/router/ubios/setup.go#L107).

This manifests in additional networks behind the dream machine not being routed to the nextdns service correctly. That means that the protections provided by nextdns are not implemented on the additional networks. This patch identifies and lists the interfaces and then adds the additional ip6tables rules for each.
