### PR TITLE
host: implement log following for systemd-journald

### DIFF
--- a/host/log_bsd.go
+++ b/host/log_bsd.go
@@ -1,8 +1,10 @@
+//go:build freebsd || openbsd || netbsd || dragonfly
 // +build freebsd openbsd netbsd dragonfly
 
 package host
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -19,4 +21,8 @@ func ReadLog(name string) ([]byte, error) {
 		logFile = "/var/log/system.log"
 	}
 	return exec.Command("grep", fmt.Sprintf(` %s\(:\|\[\)`, name), logFile).Output()
+}
+
+func FollowLog(name string) error {
+	return errors.New("-f/--follow not implemented")
 }

--- a/host/log_darwin.go
+++ b/host/log_darwin.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"errors"
 	"os/exec"
 )
 
@@ -10,4 +11,8 @@ func newServiceLogger(name string) (Logger, error) {
 
 func ReadLog(process string) ([]byte, error) {
 	return exec.Command("grep", process, "/var/log/system.log").Output()
+}
+
+func FollowLog(name string) error {
+	return errors.New("-f/--follow not implemented")
 }

--- a/host/log_linux.go
+++ b/host/log_linux.go
@@ -26,7 +26,7 @@ func ReadLog(name string) ([]byte, error) {
 	// Systemd
 	if _, err := exec.LookPath("journalctl"); err == nil {
 		b, err := exec.Command("journalctl", "-q", "-b", "-u", name).Output()
-		// If journalctl returns not output, try with another logging system.
+		// If journalctl returns no output, try with another logging system.
 		if err != nil || len(b) > 0 {
 			return b, err
 		}
@@ -36,4 +36,20 @@ func ReadLog(name string) ([]byte, error) {
 		return exec.Command("grep", fmt.Sprintf(` %s\(:\|\[\)`, name), "/var/log/messages").Output()
 	}
 	return nil, errors.New("not supported")
+}
+
+// FollowLog attempts to follow the logs from systemd-journald. It passes 3 additional flags to journalctl:
+//
+//	-f --follow      Follow the journal
+//	--no-pager       Do not pipe output into a pager
+//	--no-tail        Show all lines, even in follow mode
+func FollowLog(name string) error {
+	if _, err := exec.LookPath("journalctl"); err != nil {
+		return errors.New("-f/--follow not supported")
+	}
+
+	cmd := exec.Command("journalctl", "-q", "-b", "-f", "--no-pager", "--no-tail", "-u", name)
+	cmd.Stdout = os.Stdout
+
+	return cmd.Run()
 }

--- a/host/log_other.go
+++ b/host/log_other.go
@@ -1,3 +1,4 @@
+//go:build !darwin && !linux && !freebsd && !openbsd && !netbsd && !dragonfly
 // +build !darwin,!linux,!freebsd,!openbsd,!netbsd,!dragonfly
 
 package host
@@ -9,4 +10,8 @@ import (
 
 func ReadLog(process string) (io.Reader, error) {
 	return nil, errors.New("not implemented")
+}
+
+func FollowLog(name string) error {
+	return errors.New("-f/--follow not implemented")
 }

--- a/service.go
+++ b/service.go
@@ -79,6 +79,14 @@ func svc(args []string) error {
 		fmt.Println(status)
 		return nil
 	case "log":
+		if len(args) > 0 {
+			// If user reqeusts log following, otherwise fall through
+			// to default behaviour.
+			if args[0] == "-f" || args[0] == "--follow" {
+				return host.FollowLog("nextdns")
+			}
+		}
+
 		l, err := host.ReadLog("nextdns")
 		fmt.Printf("%s", l)
 		return err


### PR DESCRIPTION
## Description
I submitted this [feature request](https://github.com/nextdns/nextdns/issues/357) a couple of years back and finally had time to implement it. It enables journald log following on Linux systems only.

### Usage
An optional follow flag `-f/--follow` has been added to the `log` command. If not specified, then the default log behavior will persist.

I have tested this on my machine using:
- `go build`
- `./nextdns log -f`
- Logs are streamed to stdout.

Happy to close if this isn't something that's deemed needed. I can also unit test all of this if we decide to go ahead with the new functionality.