### PR TITLE
Skip * hostnames in dnsmasq lease file

### DIFF
--- a/discovery/dhcp.go
+++ b/discovery/dhcp.go
@@ -174,10 +174,12 @@ func readDNSMasqLease(r io.Reader) (macs, addrs, names map[string][]string, err 
 	for s.Scan() {
 		fields := strings.Fields(s.Text())
 		if len(fields) >= 5 {
-			name := absDomainName([]byte(fields[3]))
-			h := []byte(name)
-			lowerASCIIBytes(h)
-			key := absDomainName(h)
+			hostname := fields[3]
+			if hostname == "*" {
+				continue
+			}
+			name := absDomainName([]byte(hostname))
+			key := strings.ToLower(name)
 			mac := strings.ToLower(fields[1])
 			ip := strings.ToLower(fields[2])
 			macs[mac] = appendUniq(macs[mac], name)

--- a/discovery/dhcp_test.go
+++ b/discovery/dhcp_test.go
@@ -106,6 +106,7 @@ func Test_readDNSMasqLease(t *testing.T) {
 56789 00:0f:66:4c:fc:c8 192.168.50.12 wrt54g 01:00:0f:66:4c:fc:c8
 86400 94:83:c4:01:0b:b0 192.168.50.11 GL-MT300N-V2-bb0 *
 77060 18:e8:29:af:bd:8a 192.168.50.111 ubnt *
+86400 0b:97:88:60:b0:7a 192.168.50.50 * 0b:97:88:60:b0:7a
 			`,
 			wantMACs: map[string][]string{
 				"00:0f:66:4c:fc:c8": {"wrt54g."},


### PR DESCRIPTION
Hi @rs, here is a quick fix for a regression I found.

`*` hostnames in the dnsmasq lease file were previously ignored during discovery (see https://github.com/nextdns/nextdns/commit/a533720b781de6e00efc33eda461fc73d636195a) but this change was accidentally lost during refactoring ([see here](https://github.com/nextdns/nextdns/commit/29b36779b4ca0a02cbe15627a252374f8d3d1c34#diff-a03cef345cd9a9be021d714665b8c3224e84ccb481c7ecab2d8d2aa052450bd9L95-L97)).

I also remove a redundant duplicate call to `absDomainName`.

Please let me know what you think. Thanks!