### PR TITLE
Fix missing '<' on custom_clientlist

### DIFF
--- a/discovery/merlin_linux.go
+++ b/discovery/merlin_linux.go
@@ -96,6 +96,12 @@ func readClientList(b []byte) (macs map[string][]string, err error) {
 	if len(b) == 0 {
 		return nil, nil
 	}
+	
+	// Dirty hack - attempt to add '<' char when var is populated, but opening '<' is non-existent
+	if len(b) > 0 && b[0] != '<' {
+		b = append([]byte{'<'}, b...)
+	}
+		
 	macs = map[string][]string{}
 	for len(b) > 0 {
 		switch b[0] {

--- a/discovery/merlin_linux.go
+++ b/discovery/merlin_linux.go
@@ -97,10 +97,7 @@ func readClientList(b []byte) (macs map[string][]string, err error) {
 		return nil, nil
 	}
 
-	// Dirty hack - attempt to add '<' char when var is populated, but opening '<' is non-existent
-	if len(b) > 0 && b[0] != '<' {
-		b = append([]byte{'<'}, b[0:]...)
-	}
+
 
 	macs = map[string][]string{}
 	for len(b) > 0 {

--- a/discovery/merlin_linux.go
+++ b/discovery/merlin_linux.go
@@ -92,46 +92,39 @@ func (r *Merlin) clientListLocked() error {
 	return nil
 }
 
-func readClientList(b []byte) (macs map[string][]string, err error) {
+func readClientList(b []byte) (map[string][]string, error) {
 	if len(b) == 0 {
 		return nil, nil
 	}
-	
+
 	// Dirty hack - attempt to add '<' char when var is populated, but opening '<' is non-existent
 	if len(b) > 0 && b[0] != '<' {
 		b = append([]byte{'<'}, b...)
 	}
-		
-	macs = map[string][]string{}
+
+	macs := make(map[string][]string)
 	for len(b) > 0 {
 		switch b[0] {
 		case '<':
-			// parse
+			idx := bytes.IndexByte(b, '>')
+			if idx == -1 {
+				return nil, fmt.Errorf("%s: invalid format: missing host separator", string(b))
+			}
+			idx2 := idx + 18
+			if idx2 > len(b) || len(b) <= idx2 || b[idx2] != '>' {
+				return nil, fmt.Errorf("%s: invalid format: missing MAC separator", string(b))
+			}
+			if idx > 0 {
+				name := string(b[1:idx])
+				mac := string(bytes.ToLower(b[idx+1 : idx2]))
+				macs[mac] = appendUniq(macs[mac], name)
+			}
+			b = b[idx2+1:]
 		case '\n', '\r':
 			b = b[1:]
-			continue
 		default:
 			return nil, fmt.Errorf("%s: invalid format: missing item separator", string(b))
 		}
-		b = b[1:]
-		eol := bytes.IndexByte(b, '<')
-		if eol == -1 {
-			eol = len(b)
-		}
-		idx := bytes.IndexByte(b, '>')
-		if idx == -1 {
-			return nil, fmt.Errorf("%s: invalid format: missing host separator", string(b))
-		}
-		idx2 := idx + 18
-		if idx2 > eol || len(b) <= idx2 || b[idx2] != '>' {
-			return nil, fmt.Errorf("%s: invalid format: missing MAC separator", string(b))
-		}
-		if idx > 0 {
-			name := string(b[:idx])
-			mac := string(bytes.ToLower(b[idx+1 : idx2]))
-			macs[mac] = appendUniq(macs[mac], name)
-		}
-		b = b[eol:]
 	}
 	return macs, nil
 }

--- a/discovery/merlin_linux.go
+++ b/discovery/merlin_linux.go
@@ -84,6 +84,10 @@ func (r *Merlin) clientListLocked() error {
 	if err != nil {
 		return err
 	}
+	// Dirty hack - attempt to add '<' char when var is populated, but opening '<' is non-existent
+	if len(b) > 0 && b[0] != '<' {
+		b = append([]byte{'<'}, b[0:]...)
+	}
 	macs, err := readClientList(b)
 	if err != nil {
 		return err
@@ -96,8 +100,6 @@ func readClientList(b []byte) (macs map[string][]string, err error) {
 	if len(b) == 0 {
 		return nil, nil
 	}
-
-
 
 	macs = map[string][]string{}
 	for len(b) > 0 {

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -83,7 +83,7 @@ func Test_readClientList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, got, err := readClientList([]byte(tt.input))
+			got, err := readClientList([]byte(tt.input))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("readClientList() Err %v, want %v", err, tt.wantErr)
 			}

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -23,7 +23,7 @@ func Test_readClientList(t *testing.T) {
 			"Empty Line",
 			"\n",
 			false,
-			nil,
+				map[string][]string{},
 		},
 		{
 			"One host",

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -23,7 +23,7 @@ func Test_readClientList(t *testing.T) {
 			"Empty Line",
 			"\n",
 			false,
-			make(map[string][]string),
+			nil,
 		},
 		{
 			"One host",

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -7,7 +7,6 @@ import (
 
 func Test_readClientList(t *testing.T) {
 	// Format: <Hostname1>00:00:00:00:00:01>0>4>><Hostname2>00:00:00:00:00:02>0>24>>...
-	// Format2: Hostname1>00:00:00:00:00:01>0>4>><Hostname2>00:00:00:00:00:02>0>24>>...
 	tests := []struct {
 		name    string
 		input   string
@@ -52,7 +51,7 @@ func Test_readClientList(t *testing.T) {
 			},
 		},
 		{
-			"Two hosts without starting <",
+			"Two hosts, missing starting <",
 			"foo>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
 			false,
 			map[string][]string{

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -51,15 +51,6 @@ func Test_readClientList(t *testing.T) {
 			},
 		},
 		{
-			"Two hosts, missing starting <",
-			"foo>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
-			false,
-			map[string][]string{
-				"00:00:00:00:00:01": []string{"foo"},
-				"00:00:00:00:00:02": []string{"bar"},
-			},
-		},
-		{
 			"Skip Empty Host",
 			"<>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
 			false,

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -31,7 +31,15 @@ func Test_readClientList(t *testing.T) {
 			"<foo>00:00:00:00:00:01>0>4>>",
 			false,
 			map[string][]string{
-				"00:00:00:00:00:01": []string{"foo."},
+				"00:00:00:00:00:01": []string{"foo"},
+			},
+		},
+		{
+			"With Spaces",
+			"<Foo Bar>00:00:00:00:00:01>0>4>>",
+			false,
+			map[string][]string{
+				"00:00:00:00:00:01": []string{"Foo Bar"},
 			},
 		},
 		{
@@ -39,8 +47,8 @@ func Test_readClientList(t *testing.T) {
 			"<foo>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
 			false,
 			map[string][]string{
-				"00:00:00:00:00:01": []string{"foo."},
-				"00:00:00:00:00:02": []string{"bar."},
+				"00:00:00:00:00:01": []string{"foo"},
+				"00:00:00:00:00:02": []string{"bar"},
 			},
 		},
 		{
@@ -48,8 +56,8 @@ func Test_readClientList(t *testing.T) {
 			"foo>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
 			false,
 			map[string][]string{
-				"00:00:00:00:00:01": []string{"foo."},
-				"00:00:00:00:00:02": []string{"bar."},
+				"00:00:00:00:00:01": []string{"foo"},
+				"00:00:00:00:00:02": []string{"bar"},
 			},
 		},
 		{
@@ -57,7 +65,7 @@ func Test_readClientList(t *testing.T) {
 			"<>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
 			false,
 			map[string][]string{
-				"00:00:00:00:00:02": []string{"bar."},
+				"00:00:00:00:00:02": []string{"bar"},
 			},
 		},
 		{

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -23,7 +23,7 @@ func Test_readClientList(t *testing.T) {
 			"Empty Line",
 			"\n",
 			false,
-			map[string][]string{},
+			map[string][]string,
 		},
 		{
 			"One host",

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -23,7 +23,7 @@ func Test_readClientList(t *testing.T) {
 			"Empty Line",
 			"\n",
 			false,
-			map[string][]string,
+			make(map[string][]string),
 		},
 		{
 			"One host",

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -7,6 +7,7 @@ import (
 
 func Test_readClientList(t *testing.T) {
 	// Format: <Hostname1>00:00:00:00:00:01>0>4>><Hostname2>00:00:00:00:00:02>0>24>>...
+	// Format2: Hostname1>00:00:00:00:00:01>0>4>><Hostname2>00:00:00:00:00:02>0>24>>...
 	tests := []struct {
 		name    string
 		input   string
@@ -30,15 +31,7 @@ func Test_readClientList(t *testing.T) {
 			"<foo>00:00:00:00:00:01>0>4>>",
 			false,
 			map[string][]string{
-				"00:00:00:00:00:01": []string{"foo"},
-			},
-		},
-		{
-			"With Spaces",
-			"<Foo Bar>00:00:00:00:00:01>0>4>>",
-			false,
-			map[string][]string{
-				"00:00:00:00:00:01": []string{"Foo Bar"},
+				"00:00:00:00:00:01": []string{"foo."},
 			},
 		},
 		{
@@ -46,8 +39,17 @@ func Test_readClientList(t *testing.T) {
 			"<foo>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
 			false,
 			map[string][]string{
-				"00:00:00:00:00:01": []string{"foo"},
-				"00:00:00:00:00:02": []string{"bar"},
+				"00:00:00:00:00:01": []string{"foo."},
+				"00:00:00:00:00:02": []string{"bar."},
+			},
+		},
+		{
+			"Two hosts without starting <",
+			"foo>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
+			false,
+			map[string][]string{
+				"00:00:00:00:00:01": []string{"foo."},
+				"00:00:00:00:00:02": []string{"bar."},
 			},
 		},
 		{
@@ -55,7 +57,7 @@ func Test_readClientList(t *testing.T) {
 			"<>00:00:00:00:00:01>0>4>><bar>00:00:00:00:00:02>0>24>>",
 			false,
 			map[string][]string{
-				"00:00:00:00:00:02": []string{"bar"},
+				"00:00:00:00:00:02": []string{"bar."},
 			},
 		},
 		{
@@ -73,7 +75,7 @@ func Test_readClientList(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := readClientList([]byte(tt.input))
+			_, got, err := readClientList([]byte(tt.input))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("readClientList() Err %v, want %v", err, tt.wantErr)
 			}

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -23,7 +23,7 @@ func Test_readClientList(t *testing.T) {
 			"Empty Line",
 			"\n",
 			false,
-			map[string][]string{},
+			nil,
 		},
 		{
 			"One host",

--- a/discovery/merlin_linux_test.go
+++ b/discovery/merlin_linux_test.go
@@ -23,7 +23,7 @@ func Test_readClientList(t *testing.T) {
 			"Empty Line",
 			"\n",
 			false,
-			nil,
+			map[string][]string{},
 		},
 		{
 			"One host",


### PR DESCRIPTION
On new firmwares, after reboot, the '<' char in the beginning of the string is removed (not a bug?). This fix attemps to add it if non present.

This fixes #839 