### PR TITLE
Fix missing '<' on custom_clientlist

### DIFF
--- a/discovery/merlin_linux.go
+++ b/discovery/merlin_linux.go
@@ -84,6 +84,11 @@ func (r *Merlin) clientListLocked() error {
 	if err != nil {
 		return err
 	}
+	// Dirty hack - attempt to add '<' char when var is populated, but opening '<' is non-existent
+	if len(b) > 0 && b[0] != '<' {
+		b = append([]byte{'<'}, b[0:]...)
+	}
+	// DH end
 	macs, err := readClientList(b)
 	if err != nil {
 		return err


### PR DESCRIPTION
On new firmwares, after reboot, the '<' char in the beginning of the string is removed (not a bug?). This fix attemps to add it if non present.

This fixes #839