### PR TITLE
Fix changelog for workflows

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,7 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -20,7 +20,9 @@ jobs:
         go-version: 1.21.5
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
     - name: Run go vet
       run: go vet ./...


### PR DESCRIPTION
By default, a shallow clone is done and git log does not have the full log. Request a full clone to avoid that.
Related pull Request : #908