### PR TITLE
service: fix detection of VyOS

### DIFF
--- a/host/service/vyos/service.go
+++ b/host/service/vyos/service.go
@@ -8,8 +8,8 @@ import (
 )
 
 func isVyOS() bool {
-	if st, err := os.Stat("/config/scripts/"); err != nil || !st.IsDir() {
-		if _, err = os.Stat("/usr/libexec/vyos/init/vyos-router"); err != nil {
+	if st, err := os.Stat("/config/scripts/"); err == nil && st.IsDir() {
+		if _, err = os.Stat("/usr/libexec/vyos/init/vyos-router"); err == nil {
 			return true
 		}
 	}


### PR DESCRIPTION
The conditions were reversed. Maybe it would be more future-proof to parse /etc/os-release instead?