### PR TITLE
Remove unneeded "-bogus-priv" setting on update

### DIFF
--- a/.goreleaser/apk/post-upgrade
+++ b/.goreleaser/apk/post-upgrade
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-nextdns install -bogus-priv
+nextdns install
 
 exit 0

--- a/.goreleaser/deb/postinst
+++ b/.goreleaser/deb/postinst
@@ -15,6 +15,6 @@ EOF
     fi
 fi
 
-nextdns install #-bogus-priv # Overwrites user set "false" upon update.
+nextdns install
 
 exit 0

--- a/.goreleaser/deb/postinst
+++ b/.goreleaser/deb/postinst
@@ -15,6 +15,6 @@ EOF
     fi
 fi
 
-nextdns install -bogus-priv
+nextdns install #-bogus-priv # Overwrites user set "false" upon update.
 
 exit 0

--- a/.goreleaser/rpm/post
+++ b/.goreleaser/rpm/post
@@ -12,6 +12,6 @@ if [ -n "$repo" ] \
     curl -sL https://repo.nextdns.io/nextdns.repo > $repo
 fi
 
-nextdns install -bogus-priv
+nextdns install
 
 exit 0


### PR DESCRIPTION
This should stop the overwriting of a user set bogus-priv=false during update process.
#952 