### PR TITLE
fix: add timeout to endpoint test goroutines to prevent goroutine leaks

### DIFF
--- a/resolver/endpoint/manager.go
+++ b/resolver/endpoint/manager.go
@@ -327,7 +327,9 @@ func (e *activeEnpoint) setTesting(testing, resetTimer bool) bool {
 func (e *activeEnpoint) test() {
 	if e.setTesting(true, false) {
 		go func() {
-			err := e.manager.Test(context.Background())
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			err := e.manager.Test(ctx)
 			reset := err == nil // do not reset test timer if test failed.
 			e.setTesting(false, reset)
 		}()


### PR DESCRIPTION
The activeEnpoint.test() method spawns a goroutine that calls manager.Test(context.Background()). Since context.Background() is never cancelled, if Test() hangs — due to mutex contention, an unresponsive upstream server, or a network issue — the goroutine leaks and is never reclaimed.

Replace context.Background() with a context that has a 30-second timeout. This is generous enough to allow the full test cycle (which internally applies 5-second timeouts per individual endpoint test) while ensuring that the goroutine will always terminate. This prevents goroutine accumulation under adverse network conditions.