### PR TITLE
fix: unsubscribe netstatus channel on context cancellation

### DIFF
--- a/run.go
+++ b/run.go
@@ -434,6 +434,10 @@ func run(args []string) error {
 		p.OnInit = append(p.OnInit, func(ctx context.Context) {
 			netChange := make(chan netstatus.Change)
 			netstatus.Notify(netChange)
+			go func() {
+				<-ctx.Done()
+				netstatus.Stop(netChange)
+			}()
 			for c := range netChange {
 				log.Infof("Network change detected: %s", c)
 				startup = time.Now() // reset the startup marker so DNS fallback can happen again.


### PR DESCRIPTION
In run.go, the OnInit callback registers a netstatus change channel via netstatus.Notify() but never calls netstatus.Stop() to unsubscribe when the proxy shuts down. This means the channel subscriber persists in the global handlers slice indefinitely, and the goroutine running the for-range loop over the channel blocks forever since nothing closes it.

Add a goroutine that watches for ctx.Done() and calls netstatus.Stop(netChange) to properly unsubscribe the channel when the proxy context is cancelled. This allows the netstatus checker goroutine to terminate if no subscribers remain, and prevents the network change listener goroutine from leaking.