### PR TITLE
fix: correct channel variable in netstatus.Stop()

### DIFF
--- a/netstatus/netstatus.go
+++ b/netstatus/netstatus.go
@@ -44,7 +44,7 @@ func Stop(c chan<- Change) {
 	var newC = make([]chan<- Change, 0, len(handlers.c)-1)
 	for _, ch := range handlers.c {
 		if ch != c {
-			newC = append(newC, c)
+			newC = append(newC, ch)
 		}
 	}
 	handlers.c = newC


### PR DESCRIPTION
The Stop() function in netstatus/netstatus.go has a bug on line 47 where it appends the wrong variable when rebuilding the subscriber list. When iterating over registered channels to remove one, the code appends `c` (the channel being removed) instead of `ch` (the channel being kept).

This causes all remaining subscribers to be replaced with copies of the channel that was supposed to be removed. For example, removing channel B from subscribers [A, B, C] produces [B, B] instead of the correct [A, C].

The fix changes `append(newC, c)` to `append(newC, ch)` so that channels not matching the removal target are correctly preserved.