### PR TITLE
fix: close old transport connections on endpoint switch

### DIFF
--- a/resolver/endpoint/doh.go
+++ b/resolver/endpoint/doh.go
@@ -101,3 +101,20 @@ func (e *DOHEndpoint) RoundTrip(req *http.Request) (resp *http.Response, err err
 	})
 	return e.transport.RoundTrip(req)
 }
+
+// closeTransport closes idle connections on the underlying *http.Transport.
+// The transport field is wrapped in package-internal types (transport and
+// optionally roundTripperConnectTracer), so we unwrap through them to reach
+// the concrete *http.Transport.
+func (e *DOHEndpoint) closeTransport() {
+	rt := e.transport
+	if t, ok := rt.(transport); ok {
+		rt = t.RoundTripper
+	}
+	if t, ok := rt.(roundTripperConnectTracer); ok {
+		rt = t.RoundTripper
+	}
+	if t, ok := rt.(*http.Transport); ok {
+		t.CloseIdleConnections()
+	}
+}

--- a/resolver/endpoint/manager.go
+++ b/resolver/endpoint/manager.go
@@ -184,6 +184,15 @@ func (m *Manager) newActiveEndpointLocked(e Endpoint) (ae *activeEnpoint) {
 		return m.activeEndpoint
 	}
 
+	// Close idle connections on the old endpoint's transport so the
+	// underlying TCP+TLS connection is released immediately rather than
+	// waiting for GC to run the finalizer.
+	if m.activeEndpoint != nil {
+		if doh, ok := m.activeEndpoint.Endpoint.(*DOHEndpoint); ok {
+			doh.closeTransport()
+		}
+	}
+
 	ae = &activeEnpoint{
 		Endpoint: e,
 		manager:  m,


### PR DESCRIPTION
When the endpoint manager switches to a new endpoint, the old DOHEndpoint's http.Transport and its underlying TCP+TLS connection are dereferenced but not explicitly closed. Cleanup only happens when the GC finalizer runs (transport_h2.go:49-51), which is non-deterministic. This leaves orphaned connections holding open file descriptors and kernel resources until GC catches up.

Add a closeTransport() method to DOHEndpoint that unwraps through the package-internal transport wrapper types (transport and roundTripperConnectTracer) to reach the concrete *http.Transport and call CloseIdleConnections(). This is called from newActiveEndpointLocked() when the active endpoint is being replaced with a different one, ensuring the old connection is released immediately at the point of switch.