### PR TITLE
feat: add DNS-over-TLS and DNS-over-HTTPS listener support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,10 @@ import (
 type Config struct {
 	File                 string
 	Listens              []string
+	ListensDot           []string
+	ListensDoh           []string
+	TLSCert              string
+	TLSKey               string
 	Control              string
 	ConfigDeprecated     Profiles
 	Profile              Profiles
@@ -90,6 +94,24 @@ func (c *Config) flagSet(cmd string) flagSet {
 	}
 	fs.BoolVar(&c.Debug, "debug", false, "Enable debug logs.")
 	fs.StringsVar(&c.Listens, "listen", "Listen address for UDP DNS proxy server.")
+	fs.StringsVar(&c.ListensDot, "listen-dot",
+		"Listen address for DNS-over-TLS server. If set, a TLS certificate\n"+
+			"is required (provide via -tls-cert/-tls-key or a self-signed\n"+
+			"certificate will be generated).\n"+
+			"\n"+
+			"Example: -listen-dot localhost:853")
+	fs.StringsVar(&c.ListensDoh, "listen-doh",
+		"Listen address for DNS-over-HTTPS server. If set, a TLS certificate\n"+
+			"is required (provide via -tls-cert/-tls-key or a self-signed\n"+
+			"certificate will be generated).\n"+
+			"\n"+
+			"Example: -listen-doh localhost:443")
+	fs.StringVar(&c.TLSCert, "tls-cert", "",
+		"Path to PEM-encoded TLS certificate for DoT/DoH listeners.\n"+
+			"If not set and DoT/DoH is enabled, a self-signed certificate\n"+
+			"will be generated.")
+	fs.StringVar(&c.TLSKey, "tls-key", "",
+		"Path to PEM-encoded TLS private key for DoT/DoH listeners.")
 	fs.StringVar(&c.Control, "control", DefaultControl, "Address to the control socket.")
 	fs.Var(&c.ConfigDeprecated, "config", "deprecated, use -profile instead")
 	fs.Var(&c.Profile, "profile",

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,7 @@ require (
 	golang.org/x/sys v0.39.0
 )
 
-require github.com/dustin/go-humanize v1.0.1 // indirect
+require (
+	github.com/dustin/go-humanize v1.0.1 // indirect
+	golang.org/x/text v0.32.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -20,5 +20,7 @@ golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
 golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
+golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/proxy/doh_server.go
+++ b/proxy/doh_server.go
@@ -1,0 +1,158 @@
+package proxy
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/nextdns/nextdns/internal/dnsmessage"
+	"github.com/nextdns/nextdns/resolver"
+	"github.com/nextdns/nextdns/resolver/query"
+)
+
+// serveDoH starts an HTTP/2 server on l that accepts DNS-over-HTTPS queries
+// per RFC 8484. Both POST (binary body) and GET (?dns= base64url) are supported.
+func (p Proxy) serveDoH(l net.Listener, inflightRequests chan struct{}) error {
+	bpool := &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, maxTCPSize)
+		},
+	}
+
+	srv := &http.Server{
+		Handler: p.dohHandler(inflightRequests, bpool),
+	}
+	return srv.Serve(l)
+}
+
+func (p Proxy) dohHandler(inflightRequests chan struct{}, bpool *sync.Pool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/dns-query" {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+
+		var payload []byte
+		var err error
+
+		switch r.Method {
+		case http.MethodPost:
+			if ct := r.Header.Get("Content-Type"); ct != "application/dns-message" {
+				http.Error(w, "Unsupported Media Type", http.StatusUnsupportedMediaType)
+				return
+			}
+			payload, err = io.ReadAll(io.LimitReader(r.Body, maxTCPSize))
+			if err != nil {
+				http.Error(w, "Bad Request", http.StatusBadRequest)
+				return
+			}
+		case http.MethodGet:
+			dnsParam := r.URL.Query().Get("dns")
+			if dnsParam == "" {
+				http.Error(w, "Missing dns parameter", http.StatusBadRequest)
+				return
+			}
+			payload, err = base64.RawURLEncoding.DecodeString(dnsParam)
+			if err != nil {
+				http.Error(w, "Invalid dns parameter", http.StatusBadRequest)
+				return
+			}
+		default:
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if len(payload) <= 14 {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		// Throttle inflight requests.
+		select {
+		case inflightRequests <- struct{}{}:
+		default:
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+
+		start := time.Now()
+		buf := bpool.Get().([]byte)
+		rbuf := bpool.Get().([]byte)
+
+		var rsize int
+		var ri resolver.ResolveInfo
+
+		// Determine peer IP from the connection.
+		peerIP := net.IP{}
+		if addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
+			_ = addr // local addr, not peer
+		}
+		if host, _, splitErr := net.SplitHostPort(r.RemoteAddr); splitErr == nil {
+			peerIP = net.ParseIP(host)
+		}
+		localIP := net.IP{}
+		if addr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
+			if host, _, splitErr := net.SplitHostPort(addr.String()); splitErr == nil {
+				localIP = net.ParseIP(host)
+			}
+		}
+
+		copy(buf[:len(payload)], payload)
+		q, qerr := query.New(buf[:len(payload)], peerIP, localIP)
+
+		defer func() {
+			if rec := recover(); rec != nil {
+				stackBuf := make([]byte, 64<<10)
+				stackBuf = stackBuf[:runtime.Stack(stackBuf, false)]
+				qerr = fmt.Errorf("panic: %v: %s", rec, string(stackBuf))
+			}
+			bpool.Put(buf)
+			bpool.Put(rbuf)
+			<-inflightRequests
+			p.logQuery(QueryInfo{
+				PeerIP:            q.PeerIP,
+				Protocol:          "DoH",
+				Type:              q.Type.String(),
+				Name:              q.Name,
+				QuerySize:         len(payload),
+				ResponseSize:      rsize,
+				Duration:          time.Since(start),
+				Profile:           ri.Profile,
+				FromCache:         ri.FromCache,
+				UpstreamTransport: ri.Transport,
+				Error:             qerr,
+			})
+		}()
+
+		if qerr != nil {
+			p.logErr(qerr)
+			rsize = replyRCode(dnsmessage.RCodeFormatError, q, rbuf)
+			w.Header().Set("Content-Type", "application/dns-message")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(rbuf[:rsize])
+			return
+		}
+
+		ctx := r.Context()
+		if p.Timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, p.Timeout)
+			defer cancel()
+		}
+
+		if rsize, ri, qerr = p.Resolve(ctx, q, rbuf); qerr != nil || rsize <= 0 || rsize > maxTCPSize {
+			rsize = replyRCode(dnsmessage.RCodeServerFailure, q, rbuf)
+		}
+
+		w.Header().Set("Content-Type", "application/dns-message")
+		w.Header().Set("Cache-Control", "no-cache, no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(rbuf[:rsize])
+	})
+}

--- a/proxy/doh_server_test.go
+++ b/proxy/doh_server_test.go
@@ -1,0 +1,269 @@
+package proxy
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nextdns/nextdns/internal/dnsmessage"
+	"golang.org/x/net/http2"
+)
+
+func TestServeDoH_PostRoundTrip(t *testing.T) {
+	tlsCfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig: %v", err)
+	}
+
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	tlsListener := tls.NewListener(tcp, tlsCfg)
+	defer tlsListener.Close()
+
+	var logged []QueryInfo
+	var logMu sync.Mutex
+
+	p := Proxy{
+		Upstream:            mockResolver{},
+		MaxInflightRequests: 10,
+		QueryLog: func(qi QueryInfo) {
+			logMu.Lock()
+			logged = append(logged, qi)
+			logMu.Unlock()
+		},
+	}
+
+	inflightRequests := make(chan struct{}, p.MaxInflightRequests)
+	go p.serveDoH(tlsListener, inflightRequests)
+
+	// Build HTTP/2 client with TLS.
+	clientTLS := &tls.Config{InsecureSkipVerify: true}
+	tr := &http.Transport{
+		TLSClientConfig: clientTLS,
+	}
+	// Enable HTTP/2.
+	http2.ConfigureTransport(tr)
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
+	payload := buildQuery(t, "example.com.")
+	url := "https://" + tcp.Addr().String() + "/dns-query"
+
+	resp, err := client.Post(url, "application/dns-message", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/dns-message" {
+		t.Errorf("Content-Type = %q, want %q", ct, "application/dns-message")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var parser dnsmessage.Parser
+	hdr, err := parser.Start(body)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if !hdr.Response {
+		t.Error("response bit not set")
+	}
+	if hdr.ID != 0xABCD {
+		t.Errorf("response ID = %#x, want %#x", hdr.ID, 0xABCD)
+	}
+	if hdr.RCode != dnsmessage.RCodeSuccess {
+		t.Errorf("RCode = %d, want success", hdr.RCode)
+	}
+
+	// Wait for async query logging.
+	time.Sleep(100 * time.Millisecond)
+
+	logMu.Lock()
+	defer logMu.Unlock()
+	if len(logged) == 0 {
+		t.Fatal("no query was logged")
+	}
+	if logged[0].Protocol != "DoH" {
+		t.Errorf("logged protocol = %q, want %q", logged[0].Protocol, "DoH")
+	}
+}
+
+func TestServeDoH_GetRoundTrip(t *testing.T) {
+	tlsCfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig: %v", err)
+	}
+
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	tlsListener := tls.NewListener(tcp, tlsCfg)
+	defer tlsListener.Close()
+
+	p := Proxy{
+		Upstream:            mockResolver{},
+		MaxInflightRequests: 10,
+	}
+
+	inflightRequests := make(chan struct{}, p.MaxInflightRequests)
+	go p.serveDoH(tlsListener, inflightRequests)
+
+	clientTLS := &tls.Config{InsecureSkipVerify: true}
+	tr := &http.Transport{TLSClientConfig: clientTLS}
+	http2.ConfigureTransport(tr)
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
+	payload := buildQuery(t, "get.example.com.")
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	url := "https://" + tcp.Addr().String() + "/dns-query?dns=" + encoded
+
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	var parser dnsmessage.Parser
+	hdr, err := parser.Start(body)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if !hdr.Response {
+		t.Error("response bit not set")
+	}
+}
+
+func TestServeDoH_WrongPath(t *testing.T) {
+	tlsCfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig: %v", err)
+	}
+
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	tlsListener := tls.NewListener(tcp, tlsCfg)
+	defer tlsListener.Close()
+
+	p := Proxy{
+		Upstream:            mockResolver{},
+		MaxInflightRequests: 10,
+	}
+
+	inflightRequests := make(chan struct{}, p.MaxInflightRequests)
+	go p.serveDoH(tlsListener, inflightRequests)
+
+	clientTLS := &tls.Config{InsecureSkipVerify: true}
+	tr := &http.Transport{TLSClientConfig: clientTLS}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
+	resp, err := client.Get("https://" + tcp.Addr().String() + "/wrong-path")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestServeDoH_WrongContentType(t *testing.T) {
+	tlsCfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig: %v", err)
+	}
+
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	tlsListener := tls.NewListener(tcp, tlsCfg)
+	defer tlsListener.Close()
+
+	p := Proxy{
+		Upstream:            mockResolver{},
+		MaxInflightRequests: 10,
+	}
+
+	inflightRequests := make(chan struct{}, p.MaxInflightRequests)
+	go p.serveDoH(tlsListener, inflightRequests)
+
+	clientTLS := &tls.Config{InsecureSkipVerify: true}
+	tr := &http.Transport{TLSClientConfig: clientTLS}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
+	url := "https://" + tcp.Addr().String() + "/dns-query"
+	resp, err := client.Post(url, "text/plain", bytes.NewReader([]byte("not dns")))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnsupportedMediaType {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnsupportedMediaType)
+	}
+}
+
+func TestServeDoH_MethodNotAllowed(t *testing.T) {
+	tlsCfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig: %v", err)
+	}
+
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	tlsListener := tls.NewListener(tcp, tlsCfg)
+	defer tlsListener.Close()
+
+	p := Proxy{
+		Upstream:            mockResolver{},
+		MaxInflightRequests: 10,
+	}
+
+	inflightRequests := make(chan struct{}, p.MaxInflightRequests)
+	go p.serveDoH(tlsListener, inflightRequests)
+
+	clientTLS := &tls.Config{InsecureSkipVerify: true}
+	tr := &http.Transport{TLSClientConfig: clientTLS}
+	client := &http.Client{Transport: tr, Timeout: 5 * time.Second}
+
+	url := "https://" + tcp.Addr().String() + "/dns-query"
+	req, _ := http.NewRequest(http.MethodPut, url, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusMethodNotAllowed)
+	}
+}

--- a/proxy/dot.go
+++ b/proxy/dot.go
@@ -1,0 +1,121 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/nextdns/nextdns/internal/dnsmessage"
+	"github.com/nextdns/nextdns/resolver"
+	"github.com/nextdns/nextdns/resolver/query"
+)
+
+// serveDoT accepts TLS connections on l and handles DNS queries using the same
+// wire format as DNS-over-TCP (2-byte length prefix + DNS message). The only
+// difference from serveTCP is the protocol label logged as "DoT".
+func (p Proxy) serveDoT(l net.Listener, inflightRequests chan struct{}) error {
+	bpool := &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, maxTCPSize)
+		},
+	}
+
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				continue
+			}
+			return err
+		}
+		go func() {
+			if err := p.serveDoTConn(c, inflightRequests, bpool); err != nil {
+				if p.ErrorLog != nil {
+					p.ErrorLog(err)
+				}
+			}
+		}()
+	}
+}
+
+func (p Proxy) serveDoTConn(c net.Conn, inflightRequests chan struct{}, bpool *sync.Pool) error {
+	defer c.Close()
+
+	for {
+		inflightRequests <- struct{}{}
+		buf := bpool.Get().([]byte)
+		qsize, err := readTCP(c, buf)
+		if err != nil {
+			<-inflightRequests
+			if err.Error() == "EOF" {
+				return nil
+			}
+			return fmt.Errorf("DoT read: %v", err)
+		}
+		if qsize <= 14 {
+			<-inflightRequests
+			return fmt.Errorf("query too small: %d", qsize)
+		}
+		start := time.Now()
+		go func() {
+			var err error
+			var rsize int
+			var ri resolver.ResolveInfo
+			localIP := addrIP(c.LocalAddr())
+			remoteIP := addrIP(c.RemoteAddr())
+			q, err := query.New(buf[:qsize], remoteIP, localIP)
+			if err != nil {
+				p.logErr(err)
+			}
+			rbuf := bpool.Get().([]byte)
+			defer func() {
+				if r := recover(); r != nil {
+					stackBuf := make([]byte, 64<<10)
+					stackBuf = stackBuf[:runtime.Stack(stackBuf, false)]
+					err = fmt.Errorf("panic: %v: %s", r, string(stackBuf))
+				}
+				bpool.Put(buf)
+				bpool.Put(rbuf)
+				<-inflightRequests
+				p.logQuery(QueryInfo{
+					PeerIP:            q.PeerIP,
+					Protocol:          "DoT",
+					Type:              q.Type.String(),
+					Name:              q.Name,
+					QuerySize:         qsize,
+					ResponseSize:      rsize,
+					Duration:          time.Since(start),
+					Profile:           ri.Profile,
+					FromCache:         ri.FromCache,
+					UpstreamTransport: ri.Transport,
+					Error:             err,
+				})
+			}()
+
+			if err != nil {
+				rsize = replyRCode(dnsmessage.RCodeFormatError, q, rbuf)
+				werr := writeTCP(c, rbuf[:rsize])
+				if werr != nil {
+					err = fmt.Errorf("%v (write: %w)", err, werr)
+				}
+				return
+			}
+			ctx := context.Background()
+			if p.Timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, p.Timeout)
+				defer cancel()
+			}
+			if rsize, ri, err = p.Resolve(ctx, q, rbuf); err != nil || rsize <= 0 || rsize > maxTCPSize {
+				rsize = replyRCode(dnsmessage.RCodeServerFailure, q, rbuf)
+			}
+			werr := writeTCP(c, rbuf[:rsize])
+			if err == nil {
+				err = werr
+			}
+		}()
+	}
+}

--- a/proxy/dot_test.go
+++ b/proxy/dot_test.go
@@ -1,0 +1,232 @@
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nextdns/nextdns/internal/dnsmessage"
+	"github.com/nextdns/nextdns/resolver"
+	"github.com/nextdns/nextdns/resolver/query"
+)
+
+// mockResolver is a minimal Resolver that echoes back a success response
+// with the same question section.
+type mockResolver struct{}
+
+func (mockResolver) Resolve(_ context.Context, q query.Query, buf []byte) (int, resolver.ResolveInfo, error) {
+	var p dnsmessage.Parser
+	h, err := p.Start(q.Payload)
+	if err != nil {
+		return 0, resolver.ResolveInfo{}, err
+	}
+	question, err := p.Question()
+	if err != nil {
+		return 0, resolver.ResolveInfo{}, err
+	}
+	h.Response = true
+	h.RCode = dnsmessage.RCodeSuccess
+	h.RecursionAvailable = true
+	b := dnsmessage.NewBuilder(buf[:0], h)
+	_ = b.StartQuestions()
+	_ = b.Question(question)
+	_ = b.StartAnswers()
+	buf, _ = b.Finish()
+	return len(buf), resolver.ResolveInfo{Transport: "mock"}, nil
+}
+
+// buildQuery constructs a minimal DNS query for the given domain.
+func buildQuery(t *testing.T, domain string) []byte {
+	t.Helper()
+	buf := make([]byte, 0, 514)
+	b := dnsmessage.NewBuilder(buf, dnsmessage.Header{
+		ID:               0xABCD,
+		RecursionDesired: true,
+	})
+	if err := b.StartQuestions(); err != nil {
+		t.Fatalf("StartQuestions: %v", err)
+	}
+	if err := b.Question(dnsmessage.Question{
+		Class: dnsmessage.ClassINET,
+		Type:  dnsmessage.TypeA,
+		Name:  dnsmessage.MustNewName(domain),
+	}); err != nil {
+		t.Fatalf("Question: %v", err)
+	}
+	payload, err := b.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	return payload
+}
+
+func TestServeDoT_RoundTrip(t *testing.T) {
+	tlsCfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig: %v", err)
+	}
+
+	// Start a TCP listener on a random port.
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	tlsListener := tls.NewListener(tcp, tlsCfg)
+	defer tlsListener.Close()
+
+	var logged []QueryInfo
+	var logMu sync.Mutex
+
+	p := Proxy{
+		Upstream:            mockResolver{},
+		MaxInflightRequests: 10,
+		QueryLog: func(qi QueryInfo) {
+			logMu.Lock()
+			logged = append(logged, qi)
+			logMu.Unlock()
+		},
+	}
+
+	inflightRequests := make(chan struct{}, p.MaxInflightRequests)
+	go p.serveDoT(tlsListener, inflightRequests)
+
+	// Connect as a DoT client.
+	clientCfg := &tls.Config{InsecureSkipVerify: true}
+	conn, err := tls.Dial("tcp", tcp.Addr().String(), clientCfg)
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer conn.Close()
+
+	payload := buildQuery(t, "example.com.")
+
+	// Write query using TCP wire format (2-byte length prefix).
+	if err := binary.Write(conn, binary.BigEndian, uint16(len(payload))); err != nil {
+		t.Fatalf("write length: %v", err)
+	}
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+
+	// Read response.
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	var respLen uint16
+	if err := binary.Read(conn, binary.BigEndian, &respLen); err != nil {
+		t.Fatalf("read response length: %v", err)
+	}
+	if respLen == 0 {
+		t.Fatal("empty response")
+	}
+	resp := make([]byte, respLen)
+	if _, err := readFull(conn, resp); err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+
+	// Parse response to verify it's a valid DNS reply.
+	var parser dnsmessage.Parser
+	hdr, err := parser.Start(resp)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if !hdr.Response {
+		t.Error("response bit not set")
+	}
+	if hdr.ID != 0xABCD {
+		t.Errorf("response ID = %#x, want %#x", hdr.ID, 0xABCD)
+	}
+	if hdr.RCode != dnsmessage.RCodeSuccess {
+		t.Errorf("RCode = %d, want success", hdr.RCode)
+	}
+
+	// Wait a moment for async query logging.
+	time.Sleep(100 * time.Millisecond)
+
+	logMu.Lock()
+	defer logMu.Unlock()
+	if len(logged) == 0 {
+		t.Fatal("no query was logged")
+	}
+	if logged[0].Protocol != "DoT" {
+		t.Errorf("logged protocol = %q, want %q", logged[0].Protocol, "DoT")
+	}
+	if logged[0].Name != "example.com." {
+		t.Errorf("logged name = %q, want %q", logged[0].Name, "example.com.")
+	}
+}
+
+// readFull reads exactly len(buf) bytes from conn.
+func readFull(conn net.Conn, buf []byte) (int, error) {
+	n := 0
+	for n < len(buf) {
+		nn, err := conn.Read(buf[n:])
+		n += nn
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}
+
+func TestServeDoT_MultipleQueries(t *testing.T) {
+	tlsCfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig: %v", err)
+	}
+
+	tcp, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	tlsListener := tls.NewListener(tcp, tlsCfg)
+	defer tlsListener.Close()
+
+	p := Proxy{
+		Upstream:            mockResolver{},
+		MaxInflightRequests: 10,
+	}
+
+	inflightRequests := make(chan struct{}, p.MaxInflightRequests)
+	go p.serveDoT(tlsListener, inflightRequests)
+
+	clientCfg := &tls.Config{InsecureSkipVerify: true}
+	conn, err := tls.Dial("tcp", tcp.Addr().String(), clientCfg)
+	if err != nil {
+		t.Fatalf("tls.Dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	// Send multiple queries on the same connection.
+	domains := []string{"one.example.com.", "two.example.com.", "three.example.com."}
+	for _, domain := range domains {
+		payload := buildQuery(t, domain)
+		if err := binary.Write(conn, binary.BigEndian, uint16(len(payload))); err != nil {
+			t.Fatalf("write %s length: %v", domain, err)
+		}
+		if _, err := conn.Write(payload); err != nil {
+			t.Fatalf("write %s payload: %v", domain, err)
+		}
+
+		var respLen uint16
+		if err := binary.Read(conn, binary.BigEndian, &respLen); err != nil {
+			t.Fatalf("read %s response length: %v", domain, err)
+		}
+		resp := make([]byte, respLen)
+		if _, err := readFull(conn, resp); err != nil {
+			t.Fatalf("read %s response: %v", domain, err)
+		}
+
+		var parser dnsmessage.Parser
+		hdr, err := parser.Start(resp)
+		if err != nil {
+			t.Fatalf("parse %s response: %v", domain, err)
+		}
+		if !hdr.Response {
+			t.Errorf("%s: response bit not set", domain)
+		}
+	}
+}

--- a/proxy/tls.go
+++ b/proxy/tls.go
@@ -1,0 +1,125 @@
+package proxy
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+	"time"
+)
+
+// TLSCertConfig describes how to obtain a TLS certificate for the DoT/DoH
+// listeners.
+type TLSCertConfig struct {
+	// CertFile is the path to a PEM-encoded certificate file.
+	CertFile string
+
+	// KeyFile is the path to a PEM-encoded private key file.
+	KeyFile string
+}
+
+// LoadTLSConfig returns a *tls.Config based on the configuration. If CertFile
+// and KeyFile are set, the certificate is loaded from disk. Otherwise a
+// self-signed certificate is generated.
+func (c TLSCertConfig) LoadTLSConfig() (*tls.Config, error) {
+	var cert tls.Certificate
+	var err error
+
+	if c.CertFile != "" && c.KeyFile != "" {
+		cert, err = tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("load tls cert: %w", err)
+		}
+	} else {
+		cert, err = generateSelfSignedCert()
+		if err != nil {
+			return nil, fmt.Errorf("generate self-signed cert: %w", err)
+		}
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+		NextProtos:   []string{"h2", "http/1.1"},
+	}, nil
+}
+
+// generateSelfSignedCert creates a self-signed EC P-256 certificate valid for
+// 1 year with SANs for localhost, the system hostname (FQDN and short form),
+// 127.0.0.1, ::1, and any non-loopback LAN IPs found on the machine.
+func generateSelfSignedCert() (tls.Certificate, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "NextDNS Proxy",
+			Organization: []string{"NextDNS"},
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+	}
+
+	// Add system hostname (FQDN and short form) as SANs so clients can
+	// connect using the machine's hostname.
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		template.DNSNames = append(template.DNSNames, hostname)
+		if short, _, ok := strings.Cut(hostname, "."); ok && short != hostname {
+			template.DNSNames = append(template.DNSNames, short)
+		}
+	}
+
+	// Add LAN IPs as SANs so clients on the local network can connect
+	// without certificate errors (if they trust this cert).
+	if ifaces, err := net.Interfaces(); err == nil {
+		for _, iface := range ifaces {
+			if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+				continue
+			}
+			addrs, err := iface.Addrs()
+			if err != nil {
+				continue
+			}
+			for _, addr := range addrs {
+				if ipNet, ok := addr.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
+					template.IPAddresses = append(template.IPAddresses, ipNet.IP)
+				}
+			}
+		}
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/proxy/tls_test.go
+++ b/proxy/tls_test.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"crypto/x509"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestGenerateSelfSignedCert(t *testing.T) {
+	cert, err := generateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("generateSelfSignedCert() error: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Fatal("no certificates in TLS certificate")
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("ParseCertificate error: %v", err)
+	}
+
+	// Must include localhost as a DNS SAN.
+	found := false
+	for _, name := range x509Cert.DNSNames {
+		if name == "localhost" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DNSNames %v does not contain localhost", x509Cert.DNSNames)
+	}
+
+	// Must include system hostname if available.
+	if hostname, err := os.Hostname(); err == nil && hostname != "" {
+		found = false
+		for _, name := range x509Cert.DNSNames {
+			if name == hostname {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("DNSNames %v does not contain system hostname %q", x509Cert.DNSNames, hostname)
+		}
+
+		// If FQDN, the short form should also be present.
+		if short, _, ok := strings.Cut(hostname, "."); ok && short != hostname {
+			found = false
+			for _, name := range x509Cert.DNSNames {
+				if name == short {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("DNSNames %v does not contain short hostname %q", x509Cert.DNSNames, short)
+			}
+		}
+	}
+
+	// Must include 127.0.0.1 and ::1 as IP SANs.
+	has4, has6 := false, false
+	for _, ip := range x509Cert.IPAddresses {
+		if ip.IsLoopback() {
+			if ip.To4() != nil {
+				has4 = true
+			} else {
+				has6 = true
+			}
+		}
+	}
+	if !has4 {
+		t.Error("IPAddresses does not contain 127.0.0.1")
+	}
+	if !has6 {
+		t.Error("IPAddresses does not contain ::1")
+	}
+
+	// Verify cert metadata.
+	if x509Cert.Subject.CommonName != "NextDNS Proxy" {
+		t.Errorf("CommonName = %q, want %q", x509Cert.Subject.CommonName, "NextDNS Proxy")
+	}
+	if len(x509Cert.ExtKeyUsage) == 0 || x509Cert.ExtKeyUsage[0] != x509.ExtKeyUsageServerAuth {
+		t.Error("missing ServerAuth extended key usage")
+	}
+}
+
+func TestLoadTLSConfig_SelfSigned(t *testing.T) {
+	cfg, err := TLSCertConfig{}.LoadTLSConfig()
+	if err != nil {
+		t.Fatalf("LoadTLSConfig() error: %v", err)
+	}
+	if len(cfg.Certificates) != 1 {
+		t.Fatalf("expected 1 certificate, got %d", len(cfg.Certificates))
+	}
+	if cfg.MinVersion != 0x0303 { // tls.VersionTLS12
+		t.Errorf("MinVersion = %#x, want TLS 1.2 (%#x)", cfg.MinVersion, 0x0303)
+	}
+}
+
+func TestLoadTLSConfig_InvalidFiles(t *testing.T) {
+	_, err := TLSCertConfig{
+		CertFile: "/nonexistent/cert.pem",
+		KeyFile:  "/nonexistent/key.pem",
+	}.LoadTLSConfig()
+	if err == nil {
+		t.Fatal("expected error for nonexistent cert files")
+	}
+}


### PR DESCRIPTION
Add incoming DoT and DoH listener support for LAN/router mode, allowing clients on the local network to connect securely to the proxy.

New flags:
  -listen-dot  Listen address for DNS-over-TLS (e.g. localhost:853)
  -listen-doh  Listen address for DNS-over-HTTPS (e.g. localhost:443)
  -tls-cert    Path to PEM-encoded TLS certificate
  -tls-key     Path to PEM-encoded TLS private key

When DoT or DoH is enabled without providing a certificate, a self-signed EC P-256 certificate is auto-generated with SANs for localhost, the system hostname (FQDN and short form), loopback addresses, and all LAN IPs.

DoT reuses the existing TCP DNS wire format (2-byte length prefix) over a TLS stream. DoH implements RFC 8484 with both POST and GET methods on /dns-query, served over HTTP/2.

New files:
  proxy/tls.go            - TLS certificate management and self-signed generation
  proxy/dot.go            - DNS-over-TLS listener using TLS-wrapped TCP handler
  proxy/doh_server.go     - DNS-over-HTTPS HTTP/2 server with RFC 8484 support
  proxy/tls_test.go       - Tests for cert generation and TLS config loading
  proxy/dot_test.go       - Integration tests for DoT round-trip and pipelining
  proxy/doh_server_test.go - Integration tests for DoH POST, GET, and error cases

Modified files:
  proxy/proxy.go  - DoTAddrs, DoHAddrs, TLSConfig fields; DoT/DoH goroutines
                    in ListenAndServe; extracted resolveAddrs helper
  config/config.go - -listen-dot, -listen-doh, -tls-cert, -tls-key flags
  run.go           - Wire TLS config and new addresses into Proxy struct