### PR TITLE
feat: add cache-dump command for full cache inspection

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var commands = []command{
 	{"discovered", ctlCmd, "display discovered clients"},
 	{"cache-stats", ctlCmd, "display cache statistics"},
 	{"cache-keys", ctlCmd, "dump the list of cached entries"},
+	{"cache-dump", ctlCmd, "dump cached entries with full response data"},
 	{"trace", ctlCmd, "display a stack trace dump"},
 	{"arp", ctlCmd, "dump the ARP table"},
 	{"ndp", ctlCmd, "dump the NDP table"},

--- a/resolver/bytecache.go
+++ b/resolver/bytecache.go
@@ -2,15 +2,43 @@ package resolver
 
 import (
 	"errors"
+	"fmt"
 	"math"
+	"net"
+	"sync"
+	"time"
 
 	"github.com/dgraph-io/ristretto/v2"
+	"github.com/nextdns/nextdns/internal/dnsmessage"
+	"github.com/nextdns/nextdns/resolver/query"
 )
+
+// CacheEntry represents a single cached DNS response for external inspection.
+type CacheEntry struct {
+	Key       string        `json:"key"`
+	Domain    string        `json:"domain"`
+	Type      string        `json:"type"`
+	Class     string        `json:"class"`
+	TTL       uint32        `json:"ttl"`
+	Age       float64       `json:"age"`
+	Size      int           `json:"size"`
+	Transport string        `json:"transport"`
+	Answers   []AnswerEntry `json:"answers"`
+}
+
+// AnswerEntry represents a single resource record in a cached DNS response.
+type AnswerEntry struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	TTL  uint32 `json:"ttl"`
+	Data string `json:"data"`
+}
 
 // ByteCache is a byte-limited cache implementation for DNS responses.
 // It is backed by Ristretto and uses cost in bytes for eviction decisions.
 type ByteCache struct {
-	c *ristretto.Cache[uint64, *cacheValue]
+	c    *ristretto.Cache[uint64, *cacheValue]
+	keys sync.Map // uint64 -> string (cacheKey.String())
 }
 
 // NewByteCache creates a new byte-limited cache with maxCost expressed in bytes.
@@ -39,16 +67,24 @@ func NewByteCache(maxCost uint64, metrics bool) (*ByteCache, error) {
 		numCounters = 100_000_000
 	}
 
+	bc := &ByteCache{}
 	rc, err := ristretto.NewCache(&ristretto.Config[uint64, *cacheValue]{
 		NumCounters: numCounters,
 		MaxCost:     mc,
 		BufferItems: 64,
 		Metrics:     metrics,
+		OnEvict: func(item *ristretto.Item[*cacheValue]) {
+			bc.keys.Delete(item.Key)
+		},
+		OnReject: func(item *ristretto.Item[*cacheValue]) {
+			bc.keys.Delete(item.Key)
+		},
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &ByteCache{c: rc}, nil
+	bc.c = rc
+	return bc, nil
 }
 
 func (bc *ByteCache) Get(key uint64) (value *cacheValue, ok bool) {
@@ -66,7 +102,23 @@ func (bc *ByteCache) Set(key uint64, value *cacheValue) {
 	if cost <= 0 {
 		cost = 1
 	}
+	// Build key string from the DNS response question section.
+	bc.keys.Store(key, parseCacheKeyString("", value.msg))
 	// Ristretto's Set is async and may be dropped under contention.
+	_ = bc.c.Set(key, value, cost)
+}
+
+// SetTracked stores a cache entry and records the full key string including
+// the context (e.g. DoH URL) for later enumeration via Dump().
+func (bc *ByteCache) SetTracked(key uint64, value *cacheValue, ctx string) {
+	if bc == nil || bc.c == nil || value == nil {
+		return
+	}
+	cost := int64(len(value.msg))
+	if cost <= 0 {
+		cost = 1
+	}
+	bc.keys.Store(key, parseCacheKeyString(ctx, value.msg))
 	_ = bc.c.Set(key, value, cost)
 }
 
@@ -76,5 +128,177 @@ func (bc *ByteCache) Metrics() *ristretto.Metrics {
 		return nil
 	}
 	return bc.c.Metrics
+}
+
+// Dump returns all currently cached entries with full response data.
+func (bc *ByteCache) Dump() []CacheEntry {
+	if bc == nil || bc.c == nil {
+		return nil
+	}
+	now := time.Now()
+	var entries []CacheEntry
+	bc.keys.Range(func(k, v any) bool {
+		key := k.(uint64)
+		keyStr, _ := v.(string)
+		val, ok := bc.c.Get(key)
+		if !ok || val == nil {
+			bc.keys.Delete(key)
+			return true
+		}
+		entry := buildCacheEntry(val, keyStr, now)
+		if entry != nil {
+			entries = append(entries, *entry)
+		}
+		return true
+	})
+	return entries
+}
+
+// parseCacheKeyString extracts domain/type/class from a DNS message and
+// formats a key string matching the cacheKey.String() format.
+func parseCacheKeyString(ctx string, msg []byte) string {
+	if len(msg) < 12 {
+		return ctx
+	}
+	var p dnsmessage.Parser
+	if _, err := p.Start(msg); err != nil {
+		return ctx
+	}
+	q, err := p.Question()
+	if err != nil {
+		return ctx
+	}
+	return fmt.Sprintf("%s %s %s %s", ctx, query.Class(q.Class), query.Type(q.Type), q.Name.String())
+}
+
+// buildCacheEntry parses a cacheValue into a CacheEntry with answer records.
+func buildCacheEntry(v *cacheValue, keyStr string, now time.Time) *CacheEntry {
+	if len(v.msg) < 12 {
+		return nil
+	}
+	var p dnsmessage.Parser
+	if _, err := p.Start(v.msg); err != nil {
+		return nil
+	}
+	q, err := p.Question()
+	if err != nil {
+		return nil
+	}
+
+	age := now.Sub(v.time)
+	ageSec := uint32(age / time.Second)
+
+	// Compute remaining min TTL on a copy (updateTTL mutates in place).
+	msgCopy := append([]byte(nil), v.msg...)
+	minTTL := updateTTL(msgCopy, ageSec, 0, 0)
+
+	// Parse answer records from the age-adjusted copy.
+	answers := parseAnswers(msgCopy)
+
+	return &CacheEntry{
+		Key:       keyStr,
+		Domain:    q.Name.String(),
+		Type:      query.Type(q.Type).String(),
+		Class:     query.Class(q.Class).String(),
+		TTL:       minTTL,
+		Age:       age.Seconds(),
+		Size:      len(v.msg),
+		Transport: v.trans,
+		Answers:   answers,
+	}
+}
+
+// parseAnswers extracts answer resource records from a DNS message.
+func parseAnswers(msg []byte) []AnswerEntry {
+	var p dnsmessage.Parser
+	if _, err := p.Start(msg); err != nil {
+		return nil
+	}
+	if err := p.SkipAllQuestions(); err != nil {
+		return nil
+	}
+	var answers []AnswerEntry
+	for {
+		hdr, err := p.AnswerHeader()
+		if err != nil {
+			break
+		}
+		data := formatResourceData(&p, hdr.Type)
+		answers = append(answers, AnswerEntry{
+			Name: hdr.Name.String(),
+			Type: query.Type(hdr.Type).String(),
+			TTL:  hdr.TTL,
+			Data: data,
+		})
+	}
+	return answers
+}
+
+// formatResourceData reads the resource body and returns a human-readable string.
+func formatResourceData(p *dnsmessage.Parser, typ dnsmessage.Type) string {
+	switch typ {
+	case dnsmessage.TypeA:
+		r, err := p.AResource()
+		if err != nil {
+			return ""
+		}
+		return net.IP(r.A[:]).String()
+	case dnsmessage.TypeAAAA:
+		r, err := p.AAAAResource()
+		if err != nil {
+			return ""
+		}
+		return net.IP(r.AAAA[:]).String()
+	case dnsmessage.TypeCNAME:
+		r, err := p.CNAMEResource()
+		if err != nil {
+			return ""
+		}
+		return r.CNAME.String()
+	case dnsmessage.TypeMX:
+		r, err := p.MXResource()
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf("%d %s", r.Pref, r.MX.String())
+	case dnsmessage.TypeNS:
+		r, err := p.NSResource()
+		if err != nil {
+			return ""
+		}
+		return r.NS.String()
+	case dnsmessage.TypePTR:
+		r, err := p.PTRResource()
+		if err != nil {
+			return ""
+		}
+		return r.PTR.String()
+	case dnsmessage.TypeSOA:
+		r, err := p.SOAResource()
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf("%s %s %d %d %d %d %d",
+			r.NS.String(), r.MBox.String(),
+			r.Serial, r.Refresh, r.Retry, r.Expire, r.MinTTL)
+	case dnsmessage.TypeTXT:
+		r, err := p.TXTResource()
+		if err != nil {
+			return ""
+		}
+		if len(r.TXT) == 1 {
+			return r.TXT[0]
+		}
+		return fmt.Sprintf("%v", r.TXT)
+	case dnsmessage.TypeSRV:
+		r, err := p.SRVResource()
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf("%d %d %d %s", r.Priority, r.Weight, r.Port, r.Target.String())
+	default:
+		_ = p.SkipAnswer()
+		return fmt.Sprintf("(type %d)", typ)
+	}
 }
 

--- a/resolver/bytecache_test.go
+++ b/resolver/bytecache_test.go
@@ -1,0 +1,239 @@
+package resolver
+
+import (
+	"testing"
+	"time"
+)
+
+// testDNSResponse is a wire-format DNS response for test.com. A IN
+// with TTL 3600 and answer 69.172.200.235 (reused from cache_test.go).
+var testDNSResponse = []byte{
+	0xa6, 0xed, // ID
+	0x81, 0x80, // Flags
+	0x00, 0x01, // Questions
+	0x00, 0x01, // Answers
+	0x00, 0x00, // Authorities
+	0x00, 0x01, // Additionals
+	// Questions
+	0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x63, 0x6f, 0x6d, 0x00, // Label test.com.
+	0x00, 0x01, // Type A
+	0x00, 0x01, // Class IN
+	// Answers
+	0xc0, 0x0c, // Label pointer test.com.
+	0x00, 0x01, // Type A
+	0x00, 0x01, // Class IN
+	0x00, 0x00, 0x0e, 0x10, // TTL 3600
+	0x00, 0x04, // Data len 4
+	0x45, 0xac, 0xc8, 0xeb, // 69.172.200.235
+	// Additionals
+	0x00,       // Label <root>
+	0x00, 0x29, // Type OPT
+	0x05, 0xac, // UDP packet size
+	0x00,       // Extended RCODE
+	0x00,       // EDNS Version
+	0x00, 0x00, // Flags
+	0x00, 0x00, // DATA
+}
+
+// testDNSResponseAAAA is a wire-format DNS response for test.com. AAAA IN
+// with TTL 7200 and answer 2001:db8::1.
+var testDNSResponseAAAA = []byte{
+	0xb7, 0xfe, // ID
+	0x81, 0x80, // Flags
+	0x00, 0x01, // Questions
+	0x00, 0x01, // Answers
+	0x00, 0x00, // Authorities
+	0x00, 0x00, // Additionals
+	// Questions
+	0x04, 0x74, 0x65, 0x73, 0x74, 0x03, 0x63, 0x6f, 0x6d, 0x00, // Label test.com.
+	0x00, 0x1c, // Type AAAA
+	0x00, 0x01, // Class IN
+	// Answers
+	0xc0, 0x0c, // Label pointer test.com.
+	0x00, 0x1c, // Type AAAA
+	0x00, 0x01, // Class IN
+	0x00, 0x00, 0x1c, 0x20, // TTL 7200
+	0x00, 0x10, // Data len 16
+	0x20, 0x01, 0x0d, 0xb8, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // 2001:db8::1
+}
+
+func TestByteCache_Dump_Empty(t *testing.T) {
+	bc, err := NewByteCache(1024*1024, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries := bc.Dump()
+	if len(entries) != 0 {
+		t.Fatalf("expected empty dump, got %d entries", len(entries))
+	}
+}
+
+func TestByteCache_Dump(t *testing.T) {
+	bc, err := NewByteCache(1024*1024, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := make([]byte, len(testDNSResponse))
+	copy(msg, testDNSResponse)
+
+	v := &cacheValue{
+		time:  time.Now(),
+		msg:   msg,
+		trans: "h2",
+	}
+
+	key := uint64(12345)
+	bc.Set(key, v)
+	bc.c.Wait() // wait for ristretto async set
+
+	entries := bc.Dump()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.Domain != "test.com." {
+		t.Errorf("domain = %q, want %q", e.Domain, "test.com.")
+	}
+	if e.Type != "A" {
+		t.Errorf("type = %q, want %q", e.Type, "A")
+	}
+	if e.Class != "INET" {
+		t.Errorf("class = %q, want %q", e.Class, "INET")
+	}
+	if e.Transport != "h2" {
+		t.Errorf("transport = %q, want %q", e.Transport, "h2")
+	}
+	if e.Size != len(testDNSResponse) {
+		t.Errorf("size = %d, want %d", e.Size, len(testDNSResponse))
+	}
+	if e.TTL == 0 || e.TTL > 3600 {
+		t.Errorf("ttl = %d, want > 0 and <= 3600", e.TTL)
+	}
+	if len(e.Answers) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(e.Answers))
+	}
+	a := e.Answers[0]
+	if a.Data != "69.172.200.235" {
+		t.Errorf("answer data = %q, want %q", a.Data, "69.172.200.235")
+	}
+	if a.Type != "A" {
+		t.Errorf("answer type = %q, want %q", a.Type, "A")
+	}
+}
+
+func TestByteCache_Dump_SetTracked(t *testing.T) {
+	bc, err := NewByteCache(1024*1024, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := make([]byte, len(testDNSResponse))
+	copy(msg, testDNSResponse)
+
+	v := &cacheValue{
+		time:  time.Now(),
+		msg:   msg,
+		trans: "h2",
+	}
+
+	key := uint64(99999)
+	bc.SetTracked(key, v, "https://dns.nextdns.io/abc123")
+	bc.c.Wait()
+
+	entries := bc.Dump()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+
+	e := entries[0]
+	if e.Key == "" {
+		t.Error("expected non-empty key string")
+	}
+	// Key should contain the context URL
+	want := "https://dns.nextdns.io/abc123 INET A test.com."
+	if e.Key != want {
+		t.Errorf("key = %q, want %q", e.Key, want)
+	}
+}
+
+func TestByteCache_Dump_MultipleEntries(t *testing.T) {
+	bc, err := NewByteCache(1024*1024, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set A record
+	msgA := make([]byte, len(testDNSResponse))
+	copy(msgA, testDNSResponse)
+	vA := &cacheValue{
+		time:  time.Now(),
+		msg:   msgA,
+		trans: "h2",
+	}
+	bc.Set(uint64(1), vA)
+
+	// Set AAAA record
+	msgAAAA := make([]byte, len(testDNSResponseAAAA))
+	copy(msgAAAA, testDNSResponseAAAA)
+	vAAAA := &cacheValue{
+		time:  time.Now(),
+		msg:   msgAAAA,
+		trans: "h3",
+	}
+	bc.Set(uint64(2), vAAAA)
+
+	bc.c.Wait()
+
+	entries := bc.Dump()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	// Find each entry by type
+	var foundA, foundAAAA bool
+	for _, e := range entries {
+		switch e.Type {
+		case "A":
+			foundA = true
+			if len(e.Answers) != 1 || e.Answers[0].Data != "69.172.200.235" {
+				t.Errorf("A answer mismatch: %+v", e.Answers)
+			}
+		case "AAAA":
+			foundAAAA = true
+			if len(e.Answers) != 1 || e.Answers[0].Data != "2001:db8::1" {
+				t.Errorf("AAAA answer mismatch: %+v", e.Answers)
+			}
+			if e.Transport != "h3" {
+				t.Errorf("transport = %q, want %q", e.Transport, "h3")
+			}
+		}
+	}
+	if !foundA {
+		t.Error("A record not found in dump")
+	}
+	if !foundAAAA {
+		t.Error("AAAA record not found in dump")
+	}
+}
+
+func TestByteCache_Metrics(t *testing.T) {
+	bc, err := NewByteCache(1024*1024, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := bc.Metrics()
+	if m == nil {
+		t.Fatal("expected non-nil metrics when enabled")
+	}
+
+	bcNoMetrics, err := NewByteCache(1024*1024, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bcNoMetrics.Metrics() != nil {
+		t.Fatal("expected nil metrics when disabled")
+	}
+}

--- a/resolver/dns53.go
+++ b/resolver/dns53.go
@@ -83,7 +83,12 @@ func (r DNS53) resolve(ctx context.Context, q query.Query, buf []byte, addr stri
 			msg:  make([]byte, n),
 		}
 		copy(v.msg, buf[:n])
-		r.Cache.Set(cacheKey{"", q.Class, q.Type, q.Name}.Hash(), v)
+		k := cacheKey{"", q.Class, q.Type, q.Name}
+		if bc, ok := r.Cache.(*ByteCache); ok {
+			bc.SetTracked(k.Hash(), v, "")
+		} else {
+			r.Cache.Set(k.Hash(), v)
+		}
 	}
 	if r.MaxTTL > 0 {
 		updateTTL(buf[:n], 0, 0, r.MaxTTL)

--- a/resolver/doh.go
+++ b/resolver/doh.go
@@ -130,7 +130,12 @@ func (r *DOH) resolve(ctx context.Context, q query.Query, buf []byte, rt http.Ro
 			trans: res.Proto,
 		}
 		copy(v.msg, buf[:n])
-		r.Cache.Set(cacheKey{url, q.Class, q.Type, q.Name}.Hash(), v)
+		k := cacheKey{url, q.Class, q.Type, q.Name}
+		if bc, ok := r.Cache.(*ByteCache); ok {
+			bc.SetTracked(k.Hash(), v, url)
+		} else {
+			r.Cache.Set(k.Hash(), v)
+		}
 		r.updateLastMod(url, res.Header.Get("X-Conf-Last-Modified"))
 	}
 	if r.MaxTTL > 0 && n > 0 {

--- a/run.go
+++ b/run.go
@@ -294,6 +294,9 @@ func run(args []string) error {
 			ctl.Command("cache-stats", func(data interface{}) interface{} {
 				return p.resolver.CacheStats()
 			})
+			ctl.Command("cache-dump", func(data interface{}) interface{} {
+				return cc.Dump()
+			})
 		}
 	}
 	maxTTL := uint32(c.MaxTTL / time.Second)


### PR DESCRIPTION
Add a new `cache-dump` control command that returns all cached DNS entries as structured JSON, including domain, type, class, TTL, age, transport, and parsed answer records. This goes beyond the existing `cache-keys` command by exposing the full cached response data.

Since Ristretto v2 has no iteration API, a parallel sync.Map index tracks live keys via OnEvict/OnReject callbacks. Resolvers use SetTracked() to preserve the DoH URL context in the key string.