### PR TITLE
feat: Add remote syslog support and accompanying tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,11 @@ type Config struct {
 	SetupRouter          bool
 	AutoActivate         bool
 	Debug                bool
+	SyslogServer         string
+	SyslogPort           uint
+	SyslogTransport      string
+	SyslogLevel          string
+	SyslogFormat         string
 }
 
 func (c *Config) Parse(cmd string, args []string, useStorage bool) {
@@ -89,6 +94,17 @@ func (c *Config) flagSet(cmd string) flagSet {
 		fs.flag.StringVar(&c.File, "config-file", "", "Custom path to configuration file.")
 	}
 	fs.BoolVar(&c.Debug, "debug", false, "Enable debug logs.")
+	fs.StringVar(&c.SyslogServer, "syslog-server", "",
+		"Remote syslog server host (IP or hostname). When set, log output\n"+
+			"is forwarded over the network to this syslog target.")
+	fs.UintVar(&c.SyslogPort, "syslog-port", 0,
+		"Remote syslog server port. Defaults to 514 for udp/tcp and 6514 for tls.")
+	fs.StringVar(&c.SyslogTransport, "syslog-transport", "udp",
+		"Transport for remote syslog: udp, tcp, or tls.")
+	fs.StringVar(&c.SyslogLevel, "syslog-level", "info",
+		"Minimum log level forwarded to remote syslog: debug, info, warning, or error.")
+	fs.StringVar(&c.SyslogFormat, "syslog-format", "rfc3164",
+		"Syslog message format: rfc3164 (BSD) or rfc5424 (structured).")
 	fs.StringsVar(&c.Listens, "listen", "Listen address for UDP DNS proxy server.")
 	fs.StringVar(&c.Control, "control", DefaultControl, "Address to the control socket.")
 	fs.Var(&c.ConfigDeprecated, "config", "deprecated, use -profile instead")

--- a/host/log_remote_syslog.go
+++ b/host/log_remote_syslog.go
@@ -1,0 +1,240 @@
+package host
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Syslog severity levels (RFC 5424 Section 6.2.1).
+const (
+	severityEmergency = iota
+	severityAlert
+	severityCritical
+	severityError
+	severityWarning
+	severityNotice
+	severityInfo
+	severityDebug
+)
+
+// Syslog facility for daemon (RFC 5424 Section 6.2.1).
+const facilityDaemon = 3
+
+// maxUDPLen is the maximum safe UDP syslog message size per RFC 3164.
+const maxUDPLen = 1024
+
+// RemoteSyslogConfig holds configuration for a remote syslog logger.
+type RemoteSyslogConfig struct {
+	Server    string // host or IP (required)
+	Port      uint   // 0 = auto (514 for udp/tcp, 6514 for tls)
+	Transport string // "udp", "tcp", "tls"
+	Level     string // "debug", "info", "warning", "error"
+	Format    string // "rfc3164", "rfc5424"
+	Tag       string // syslog tag (e.g. "nextdns")
+}
+
+type remoteSyslogLogger struct {
+	mu        sync.Mutex
+	conn      net.Conn
+	addr      string
+	network   string        // "udp" or "tcp"
+	tlsConfig *tls.Config   // non-nil for TLS transport
+	level     int           // minimum severity to send (lower = more severe)
+	formatter func(severity int, tag, hostname, msg string) string
+	tag       string
+	hostname  string
+}
+
+// NewRemoteSyslogLogger creates a Logger that sends messages to a remote syslog
+// server over UDP, TCP, or TLS. The connection is established lazily on first
+// write and re-established transparently on failure.
+func NewRemoteSyslogLogger(cfg RemoteSyslogConfig) (Logger, error) {
+	if cfg.Server == "" {
+		return nil, errors.New("syslog-server is required")
+	}
+
+	var network string
+	var tlsConfig *tls.Config
+	switch strings.ToLower(cfg.Transport) {
+	case "udp", "":
+		network = "udp"
+	case "tcp":
+		network = "tcp"
+	case "tls":
+		network = "tcp"
+		tlsConfig = &tls.Config{
+			ServerName: cfg.Server,
+		}
+	default:
+		return nil, fmt.Errorf("invalid syslog-transport: %q (must be udp, tcp, or tls)", cfg.Transport)
+	}
+
+	level, err := parseLevel(cfg.Level)
+	if err != nil {
+		return nil, err
+	}
+
+	var formatter func(severity int, tag, hostname, msg string) string
+	switch strings.ToLower(cfg.Format) {
+	case "rfc3164", "":
+		formatter = formatRFC3164
+	case "rfc5424":
+		formatter = formatRFC5424
+	default:
+		return nil, fmt.Errorf("invalid syslog-format: %q (must be rfc3164 or rfc5424)", cfg.Format)
+	}
+
+	port := cfg.Port
+	if port == 0 {
+		if tlsConfig != nil {
+			port = 6514
+		} else {
+			port = 514
+		}
+	}
+
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "localhost"
+	}
+
+	tag := cfg.Tag
+	if tag == "" {
+		tag = "nextdns"
+	}
+
+	return &remoteSyslogLogger{
+		addr:      net.JoinHostPort(cfg.Server, fmt.Sprint(port)),
+		network:   network,
+		tlsConfig: tlsConfig,
+		level:     level,
+		formatter: formatter,
+		tag:       tag,
+		hostname:  hostname,
+	}, nil
+}
+
+func parseLevel(s string) (int, error) {
+	switch strings.ToLower(s) {
+	case "debug":
+		return severityDebug, nil
+	case "info", "":
+		return severityNotice, nil
+	case "warning":
+		return severityWarning, nil
+	case "error":
+		return severityError, nil
+	default:
+		return 0, fmt.Errorf("invalid syslog-level: %q (must be debug, info, warning, or error)", s)
+	}
+}
+
+func (l *remoteSyslogLogger) Debug(v ...interface{}) {
+	l.send(severityDebug, fmt.Sprint(v...))
+}
+
+func (l *remoteSyslogLogger) Debugf(format string, a ...interface{}) {
+	l.send(severityDebug, fmt.Sprintf(format, a...))
+}
+
+func (l *remoteSyslogLogger) Info(v ...interface{}) {
+	// Use notice instead of info as many systems filter < notice level.
+	l.send(severityNotice, fmt.Sprint(v...))
+}
+
+func (l *remoteSyslogLogger) Infof(format string, a ...interface{}) {
+	l.send(severityNotice, fmt.Sprintf(format, a...))
+}
+
+func (l *remoteSyslogLogger) Warning(v ...interface{}) {
+	l.send(severityWarning, fmt.Sprint(v...))
+}
+
+func (l *remoteSyslogLogger) Warningf(format string, a ...interface{}) {
+	l.send(severityWarning, fmt.Sprintf(format, a...))
+}
+
+func (l *remoteSyslogLogger) Error(v ...interface{}) {
+	l.send(severityError, fmt.Sprint(v...))
+}
+
+func (l *remoteSyslogLogger) Errorf(format string, a ...interface{}) {
+	l.send(severityError, fmt.Sprintf(format, a...))
+}
+
+func (l *remoteSyslogLogger) send(severity int, msg string) {
+	// Filter by configured level. Lower severity number = more critical.
+	if severity > l.level {
+		return
+	}
+
+	// Sanitize: replace newlines to prevent log injection.
+	msg = strings.ReplaceAll(msg, "\n", " ")
+	msg = strings.ReplaceAll(msg, "\r", " ")
+
+	line := l.formatter(severity, l.tag, l.hostname, msg)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.conn == nil {
+		if err := l.dial(); err != nil {
+			return
+		}
+	}
+
+	data := []byte(line)
+	// Truncate UDP messages to max safe size.
+	if l.network == "udp" && len(data) > maxUDPLen {
+		data = data[:maxUDPLen]
+	}
+
+	_, err := l.conn.Write(data)
+	if err != nil {
+		// Close and nil the connection so next call retries.
+		l.conn.Close()
+		l.conn = nil
+	}
+}
+
+func (l *remoteSyslogLogger) dial() error {
+	var conn net.Conn
+	var err error
+
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	if l.tlsConfig != nil {
+		conn, err = tls.DialWithDialer(&dialer, l.network, l.addr, l.tlsConfig)
+	} else {
+		conn, err = dialer.Dial(l.network, l.addr)
+	}
+	if err != nil {
+		return err
+	}
+	l.conn = conn
+	return nil
+}
+
+// priority computes the syslog PRI value: facility * 8 + severity.
+func priority(severity int) int {
+	return facilityDaemon*8 + severity
+}
+
+// formatRFC3164 produces a BSD syslog message (RFC 3164).
+// Format: <PRI>Mon DD HH:MM:SS hostname tag: message\n
+func formatRFC3164(severity int, tag, hostname, msg string) string {
+	ts := time.Now().Format(time.Stamp) // "Jan _2 15:04:05"
+	return fmt.Sprintf("<%d>%s %s %s: %s\n", priority(severity), ts, hostname, tag, msg)
+}
+
+// formatRFC5424 produces a structured syslog message (RFC 5424).
+// Format: <PRI>1 TIMESTAMP HOSTNAME TAG - - - MESSAGE\n
+func formatRFC5424(severity int, tag, hostname, msg string) string {
+	ts := time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	return fmt.Sprintf("<%d>1 %s %s %s - - - %s\n", priority(severity), ts, hostname, tag, msg)
+}

--- a/host/log_remote_syslog_test.go
+++ b/host/log_remote_syslog_test.go
@@ -1,0 +1,491 @@
+package host
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func udpListener(t *testing.T) *net.UDPConn {
+	t.Helper()
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+func udpRead(t *testing.T, conn *net.UDPConn) string {
+	t.Helper()
+	buf := make([]byte, 2048)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("udp read: %v", err)
+	}
+	return string(buf[:n])
+}
+
+func tcpListener(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	return ln
+}
+
+func tcpAcceptAndRead(t *testing.T, ln net.Listener) string {
+	t.Helper()
+	conn, err := ln.Accept()
+	if err != nil {
+		t.Fatalf("tcp accept: %v", err)
+	}
+	defer conn.Close()
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 2048)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("tcp read: %v", err)
+	}
+	return string(buf[:n])
+}
+
+func portFromAddr(addr net.Addr) uint {
+	switch a := addr.(type) {
+	case *net.UDPAddr:
+		return uint(a.Port)
+	case *net.TCPAddr:
+		return uint(a.Port)
+	}
+	return 0
+}
+
+func TestRemoteSyslog_RFC3164(t *testing.T) {
+	conn := udpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(conn.LocalAddr()),
+		Transport: "udp",
+		Level:     "info",
+		Format:    "rfc3164",
+		Tag:       "nextdns",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lg.Info("test message")
+
+	msg := udpRead(t, conn)
+	// RFC 3164: <PRI>TIMESTAMP HOSTNAME TAG: MESSAGE\n
+	// Priority for daemon.notice = 3*8 + 5 = 29
+	if !strings.HasPrefix(msg, "<29>") {
+		t.Errorf("expected priority <29>, got prefix: %q", msg[:10])
+	}
+	if !strings.Contains(msg, "nextdns: test message") {
+		t.Errorf("expected 'nextdns: test message' in %q", msg)
+	}
+	if !strings.HasSuffix(msg, "\n") {
+		t.Errorf("expected trailing newline in %q", msg)
+	}
+}
+
+func TestRemoteSyslog_RFC5424(t *testing.T) {
+	conn := udpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(conn.LocalAddr()),
+		Transport: "udp",
+		Level:     "info",
+		Format:    "rfc5424",
+		Tag:       "nextdns",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lg.Info("structured test")
+
+	msg := udpRead(t, conn)
+	// RFC 5424: <PRI>1 TIMESTAMP HOSTNAME TAG - - - MESSAGE\n
+	if !strings.HasPrefix(msg, "<29>1 ") {
+		t.Errorf("expected '<29>1 ' prefix, got: %q", msg[:10])
+	}
+	if !strings.Contains(msg, " nextdns - - - structured test") {
+		t.Errorf("expected structured data format in %q", msg)
+	}
+	// Timestamp should be ISO 8601 format with Z suffix
+	parts := strings.SplitN(msg, " ", 4)
+	if len(parts) >= 2 && !strings.HasSuffix(parts[1], "Z") {
+		t.Errorf("expected UTC timestamp ending in Z, got: %q", parts[1])
+	}
+}
+
+func TestRemoteSyslog_LevelFilter(t *testing.T) {
+	conn := udpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(conn.LocalAddr()),
+		Transport: "udp",
+		Level:     "warning",
+		Format:    "rfc3164",
+		Tag:       "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Debug and Info should be filtered out.
+	lg.Debug("should not arrive")
+	lg.Info("should not arrive either")
+
+	// Warning should arrive.
+	lg.Warning("this should arrive")
+
+	msg := udpRead(t, conn)
+	if !strings.Contains(msg, "this should arrive") {
+		t.Errorf("expected warning message, got: %q", msg)
+	}
+
+	// Error should also arrive.
+	lg.Error("error too")
+	msg = udpRead(t, conn)
+	if !strings.Contains(msg, "error too") {
+		t.Errorf("expected error message, got: %q", msg)
+	}
+}
+
+func TestRemoteSyslog_TCP(t *testing.T) {
+	ln := tcpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(ln.Addr()),
+		Transport: "tcp",
+		Level:     "info",
+		Format:    "rfc3164",
+		Tag:       "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		done <- tcpAcceptAndRead(t, ln)
+	}()
+
+	lg.Info("tcp message")
+
+	select {
+	case msg := <-done:
+		if !strings.Contains(msg, "tcp message") {
+			t.Errorf("expected 'tcp message' in %q", msg)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for TCP message")
+	}
+}
+
+func TestRemoteSyslog_Reconnect(t *testing.T) {
+	ln := tcpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(ln.Addr()),
+		Transport: "tcp",
+		Level:     "info",
+		Format:    "rfc3164",
+		Tag:       "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Accept first connection in a goroutine (logger connects lazily on
+	// first send, so Accept must not block the main goroutine).
+	firstMsg := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 2048)
+		n, err := conn.Read(buf)
+		if err != nil {
+			return
+		}
+		firstMsg <- string(buf[:n])
+	}()
+
+	lg.Info("first")
+
+	select {
+	case msg := <-firstMsg:
+		if !strings.Contains(msg, "first") {
+			t.Errorf("expected 'first' in %q", msg)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for first message")
+	}
+
+	// Force the logger to detect the broken connection by closing its conn
+	// directly — on macOS, writes to a peer-closed TCP socket may be buffered
+	// by the kernel and not fail immediately.
+	rl := lg.(*remoteSyslogLogger)
+	rl.mu.Lock()
+	if rl.conn != nil {
+		rl.conn.Close()
+		rl.conn = nil
+	}
+	rl.mu.Unlock()
+
+	// Accept the reconnection in a goroutine before writing.
+	secondMsg := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 2048)
+		n, err := conn.Read(buf)
+		if err != nil {
+			return
+		}
+		secondMsg <- string(buf[:n])
+	}()
+
+	lg.Info("second")
+
+	select {
+	case msg := <-secondMsg:
+		if !strings.Contains(msg, "second") {
+			t.Errorf("expected 'second' in reconnected message, got: %q", msg)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for reconnect message")
+	}
+}
+
+func TestRemoteSyslog_InvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  RemoteSyslogConfig
+	}{
+		{"empty server", RemoteSyslogConfig{Server: "", Transport: "udp"}},
+		{"invalid transport", RemoteSyslogConfig{Server: "localhost", Transport: "quic"}},
+		{"invalid level", RemoteSyslogConfig{Server: "localhost", Level: "trace"}},
+		{"invalid format", RemoteSyslogConfig{Server: "localhost", Format: "json"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewRemoteSyslogLogger(tt.cfg)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestRemoteSyslog_AutoPort(t *testing.T) {
+	tests := []struct {
+		transport string
+		wantPort  string
+	}{
+		{"udp", ":514"},
+		{"tcp", ":514"},
+		{"tls", ":6514"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.transport, func(t *testing.T) {
+			lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+				Server:    "192.0.2.1",
+				Port:      0,
+				Transport: tt.transport,
+				Tag:       "test",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			rl := lg.(*remoteSyslogLogger)
+			if !strings.HasSuffix(rl.addr, tt.wantPort) {
+				t.Errorf("addr = %q, want suffix %q", rl.addr, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestRemoteSyslog_Priority(t *testing.T) {
+	tests := []struct {
+		severity int
+		wantPri  int
+	}{
+		{severityDebug, 31},   // 3*8 + 7
+		{severityNotice, 29},  // 3*8 + 5
+		{severityWarning, 28}, // 3*8 + 4
+		{severityError, 27},   // 3*8 + 3
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("severity_%d", tt.severity), func(t *testing.T) {
+			got := priority(tt.severity)
+			if got != tt.wantPri {
+				t.Errorf("priority(%d) = %d, want %d", tt.severity, got, tt.wantPri)
+			}
+		})
+	}
+}
+
+func TestRemoteSyslog_UDPTruncation(t *testing.T) {
+	conn := udpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(conn.LocalAddr()),
+		Transport: "udp",
+		Level:     "debug",
+		Format:    "rfc3164",
+		Tag:       "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send a message that with header will exceed 1024 bytes.
+	longMsg := strings.Repeat("x", 1100)
+	lg.Info(longMsg)
+
+	buf := make([]byte, 2048)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n > maxUDPLen {
+		t.Errorf("UDP message length = %d, want <= %d", n, maxUDPLen)
+	}
+}
+
+func TestRemoteSyslog_ConcurrentWrites(t *testing.T) {
+	conn := udpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(conn.LocalAddr()),
+		Transport: "udp",
+		Level:     "debug",
+		Format:    "rfc3164",
+		Tag:       "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drain messages in background.
+	go func() {
+		buf := make([]byte, 2048)
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+			_, err := conn.Read(buf)
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				lg.Infof("goroutine %d msg %d", id, j)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestRemoteSyslog_LogInjection(t *testing.T) {
+	conn := udpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(conn.LocalAddr()),
+		Transport: "udp",
+		Level:     "info",
+		Format:    "rfc3164",
+		Tag:       "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Attempt log injection via newline in message.
+	lg.Info("legit\n<29>fake injected message")
+
+	msg := udpRead(t, conn)
+	// The newline should be replaced, so the message should be on one line.
+	lines := strings.Split(strings.TrimSuffix(msg, "\n"), "\n")
+	if len(lines) != 1 {
+		t.Errorf("log injection: message split into %d lines: %q", len(lines), msg)
+	}
+}
+
+func TestRemoteSyslog_TCPNoTruncation(t *testing.T) {
+	ln := tcpListener(t)
+	lg, err := NewRemoteSyslogLogger(RemoteSyslogConfig{
+		Server:    "127.0.0.1",
+		Port:      portFromAddr(ln.Addr()),
+		Transport: "tcp",
+		Level:     "debug",
+		Format:    "rfc3164",
+		Tag:       "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		b, _ := io.ReadAll(conn)
+		done <- string(b)
+	}()
+
+	// Send a long message — TCP should not truncate.
+	longMsg := strings.Repeat("y", 1500)
+	lg.Info(longMsg)
+
+	// Close the logger's connection to trigger EOF on reader side.
+	rl := lg.(*remoteSyslogLogger)
+	rl.mu.Lock()
+	if rl.conn != nil {
+		rl.conn.Close()
+		rl.conn = nil
+	}
+	rl.mu.Unlock()
+
+	select {
+	case msg := <-done:
+		if len(msg) <= maxUDPLen {
+			t.Errorf("TCP message should not be truncated, got length %d", len(msg))
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout")
+	}
+}

--- a/host/log_tee.go
+++ b/host/log_tee.go
@@ -1,0 +1,58 @@
+package host
+
+type teeLogger struct {
+	loggers []Logger
+}
+
+// NewTeeLogger returns a Logger that fans out each call to all provided loggers.
+func NewTeeLogger(loggers ...Logger) Logger {
+	return teeLogger{loggers: loggers}
+}
+
+func (l teeLogger) Debug(v ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Debug(v...)
+	}
+}
+
+func (l teeLogger) Debugf(format string, a ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Debugf(format, a...)
+	}
+}
+
+func (l teeLogger) Info(v ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Info(v...)
+	}
+}
+
+func (l teeLogger) Infof(format string, a ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Infof(format, a...)
+	}
+}
+
+func (l teeLogger) Warning(v ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Warning(v...)
+	}
+}
+
+func (l teeLogger) Warningf(format string, a ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Warningf(format, a...)
+	}
+}
+
+func (l teeLogger) Error(v ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Error(v...)
+	}
+}
+
+func (l teeLogger) Errorf(format string, a ...interface{}) {
+	for _, lg := range l.loggers {
+		lg.Errorf(format, a...)
+	}
+}

--- a/host/log_tee_test.go
+++ b/host/log_tee_test.go
@@ -1,0 +1,86 @@
+package host
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type recordingLogger struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (l *recordingLogger) record(v ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msgs = append(l.msgs, fmt.Sprint(v...))
+}
+
+func (l *recordingLogger) recordf(format string, a ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.msgs = append(l.msgs, fmt.Sprintf(format, a...))
+}
+
+func (l *recordingLogger) Debug(v ...interface{})                 { l.record(v...) }
+func (l *recordingLogger) Debugf(format string, a ...interface{}) { l.recordf(format, a...) }
+func (l *recordingLogger) Info(v ...interface{})                  { l.record(v...) }
+func (l *recordingLogger) Infof(format string, a ...interface{})  { l.recordf(format, a...) }
+func (l *recordingLogger) Warning(v ...interface{})               { l.record(v...) }
+func (l *recordingLogger) Warningf(format string, a ...interface{}) {
+	l.recordf(format, a...)
+}
+func (l *recordingLogger) Error(v ...interface{})                 { l.record(v...) }
+func (l *recordingLogger) Errorf(format string, a ...interface{}) { l.recordf(format, a...) }
+
+func (l *recordingLogger) messages() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	cp := make([]string, len(l.msgs))
+	copy(cp, l.msgs)
+	return cp
+}
+
+func TestTeeLogger(t *testing.T) {
+	a := &recordingLogger{}
+	b := &recordingLogger{}
+	tee := NewTeeLogger(a, b)
+
+	tee.Info("hello")
+
+	if msgs := a.messages(); len(msgs) != 1 || msgs[0] != "hello" {
+		t.Errorf("logger a: got %v, want [hello]", msgs)
+	}
+	if msgs := b.messages(); len(msgs) != 1 || msgs[0] != "hello" {
+		t.Errorf("logger b: got %v, want [hello]", msgs)
+	}
+}
+
+func TestTeeLogger_AllMethods(t *testing.T) {
+	a := &recordingLogger{}
+	b := &recordingLogger{}
+	tee := NewTeeLogger(a, b)
+
+	tee.Debug("d")
+	tee.Debugf("df %d", 1)
+	tee.Info("i")
+	tee.Infof("if %d", 2)
+	tee.Warning("w")
+	tee.Warningf("wf %d", 3)
+	tee.Error("e")
+	tee.Errorf("ef %d", 4)
+
+	want := []string{"d", "df 1", "i", "if 2", "w", "wf 3", "e", "ef 4"}
+	for _, lg := range []*recordingLogger{a, b} {
+		msgs := lg.messages()
+		if len(msgs) != len(want) {
+			t.Fatalf("got %d messages, want %d: %v", len(msgs), len(want), msgs)
+		}
+		for i, m := range msgs {
+			if m != want[i] {
+				t.Errorf("msg[%d] = %q, want %q", i, m, want[i])
+			}
+		}
+	}
+}

--- a/run.go
+++ b/run.go
@@ -153,6 +153,21 @@ func run(args []string) error {
 		log = host.NewConsoleLogger("nextdns")
 		log.Warningf("Service logger error (switching to console): %v", err)
 	}
+	if c.SyslogServer != "" {
+		rsLog, err := host.NewRemoteSyslogLogger(host.RemoteSyslogConfig{
+			Server:    c.SyslogServer,
+			Port:      c.SyslogPort,
+			Transport: c.SyslogTransport,
+			Level:     c.SyslogLevel,
+			Format:    c.SyslogFormat,
+			Tag:       "nextdns",
+		})
+		if err != nil {
+			log.Errorf("Remote syslog setup failed: %v", err)
+		} else {
+			log = host.NewTeeLogger(log, rsLog)
+		}
+	}
 	p := &proxySvc{
 		log: log,
 	}


### PR DESCRIPTION
### New Feature: Syslog Shipping

Implements #1047 

## Changes:
- **Feature**: **Syslog shipping for use in enterprise managed enviornments**
- configuration options in config file
- runtime configuration flags
- accompanying unit tests for CI/CD

## Definable User Configuration Settings
- Syslog target host ( IP or hostname )
- Syslog target port
- Syslog transport type: ( TCP | UDP | TLS )
- Syslog standard and format: rfc3164 | rfc5424

## Description

This is a major new feature, adding syslog event shipping to the client for those like me who use this service as a local resolver on a managed network with 100+ nodes, and want to ship logs to a syslog gateway for ingestion and SIEM processing.

