### PR TITLE
bug: strip CIDR from OpenWrt DHCP option DNS address

### DIFF
--- a/router/openwrt/setup.go
+++ b/router/openwrt/setup.go
@@ -3,6 +3,7 @@ package openwrt
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -180,6 +181,18 @@ func getRouterIP() (string, error) {
 	ip, err := uci("get", "network.lan.ipaddr")
 	if err != nil {
 		return "", fmt.Errorf("failed to get router IP address: %v", err)
+	}
+	return normalizeRouterIP(ip)
+}
+
+func normalizeRouterIP(ip string) (string, error) {
+	ip = strings.TrimSpace(ip)
+	if strings.Contains(ip, "/") {
+		prefix, err := netip.ParsePrefix(ip)
+		if err != nil {
+			return "", fmt.Errorf("invalid router IP prefix %q: %w", ip, err)
+		}
+		return prefix.Addr().String(), nil
 	}
 	return ip, nil
 }

--- a/router/openwrt/setup_test.go
+++ b/router/openwrt/setup_test.go
@@ -1,0 +1,56 @@
+package openwrt
+
+import "testing"
+
+func Test_normalizeRouterIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "ipv4",
+			input: "192.168.1.1",
+			want:  "192.168.1.1",
+		},
+		{
+			name:  "ipv4 cidr",
+			input: "192.168.2.1/24",
+			want:  "192.168.2.1",
+		},
+		{
+			name:  "ipv6 cidr",
+			input: "fd00::1/64",
+			want:  "fd00::1",
+		},
+		{
+			name:  "trim spaces",
+			input: " 192.168.3.1/24 \n",
+			want:  "192.168.3.1",
+		},
+		{
+			name:    "invalid cidr",
+			input:   "192.168.1.1/abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeRouterIP(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("normalizeRouterIP(%q) error = nil, want error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeRouterIP(%q) error = %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("normalizeRouterIP(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- OpenWrt `network.lan.ipaddr` can be configured as a CIDR (e.g. `192.168.2.1/24`) which was being written verbatim into DHCP option 6 and produced an invalid DNS server value, causing issue #1081. 
- The change ensures the router IP used for DHCP option 6 is a canonical address string (no CIDR), and surfaces a clear error for invalid CIDR inputs.

### Description
- Added `normalizeRouterIP` to `router/openwrt/setup.go` to trim whitespace and strip CIDR by parsing with `netip.ParsePrefix` and returning the prefix address via `Addr().String()`.
- `getRouterIP` now returns the normalized address by calling `normalizeRouterIP`.
- The change uses only the Go stdlib (`net/netip`) and keeps behavior unchanged when `network.lan.ipaddr` is already a plain address.
- Added unit tests in `router/openwrt/setup_test.go` covering plain IPv4, IPv4 CIDR, IPv6 CIDR, whitespace trimming, and invalid CIDR handling.

### Testing
- Ran `go test ./router/openwrt` and the tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5568e10988320a71ebd65e23f016f)