### PR TITLE
bug: preserve interface profile rules in config output

### DIFF
--- a/config/profile.go
+++ b/config/profile.go
@@ -10,6 +10,7 @@ import (
 // profile defines a profile ID with some optional conditions.
 type profile struct {
 	ID      string
+	Iface   string
 	Prefix  *net.IPNet
 	MAC     net.HardwareAddr
 	DestIPs []net.IP
@@ -49,6 +50,7 @@ func newConfig(v string) (profile, error) {
 	} else if mac, err := net.ParseMAC(cond); err == nil {
 		c.MAC = mac
 	} else if iface, _ := net.InterfaceByName(cond); iface != nil {
+		c.Iface = cond
 		addrs, _ := iface.Addrs()
 		for _, addr := range addrs {
 			if ipnet, ok := addr.(*net.IPNet); ok {
@@ -102,12 +104,15 @@ func (p profile) Match(sourceIP, destIP net.IP, mac net.HardwareAddr, user strin
 }
 
 func (p profile) isDefault() bool {
-	return p.Prefix == nil && len(p.MAC) == 0 && len(p.DestIPs) == 0 && p.User == ""
+	return p.Iface == "" && p.Prefix == nil && len(p.MAC) == 0 && len(p.DestIPs) == 0 && p.User == ""
 }
 
 func (p profile) String() string {
 	if p.User != "" {
 		return fmt.Sprintf("@%s=%s", p.User, p.ID)
+	}
+	if p.Iface != "" {
+		return fmt.Sprintf("%s=%s", p.Iface, p.ID)
 	}
 	if p.MAC != nil {
 		return fmt.Sprintf("%s=%s", p.MAC, p.ID)
@@ -179,10 +184,11 @@ func (ps *Profiles) Set(value string) error {
 	// Replace if c match the same criteria of an existing config
 	for i, _p := range *ps {
 		if (p.User != "" && p.User == _p.User) ||
+			(p.Iface != "" && p.Iface == _p.Iface) ||
 			(p.MAC != nil && _p.MAC != nil && bytes.Equal(p.MAC, _p.MAC)) ||
 			(p.DestIPs != nil && _p.DestIPs != nil && ipListEqual(p.DestIPs, _p.DestIPs)) ||
 			(p.Prefix != nil && _p.Prefix != nil && p.Prefix.String() == _p.Prefix.String()) ||
-			(p.MAC == nil && p.Prefix == nil && p.DestIPs == nil && p.User == "" && _p.MAC == nil && _p.Prefix == nil && _p.DestIPs == nil && _p.User == "") {
+			(p.Iface == "" && p.MAC == nil && p.Prefix == nil && p.DestIPs == nil && p.User == "" && _p.Iface == "" && _p.MAC == nil && _p.Prefix == nil && _p.DestIPs == nil && _p.User == "") {
 			(*ps)[i] = p
 			return nil
 		}

--- a/config/profile_test.go
+++ b/config/profile_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"fmt"
 	"net"
 	"testing"
 )
@@ -142,4 +144,61 @@ func TestProfiles_Set_ReplacesUserRule(t *testing.T) {
 	if got := ps.GetWithUser(nil, nil, nil, "rs"); got != "profile2" {
 		t.Fatalf("Profiles.GetWithUser() = %v, want %v", got, "profile2")
 	}
+}
+
+func TestProfiles_Strings_PreservesInterfaceRule(t *testing.T) {
+	iface := loopbackInterfaceName(t)
+
+	var ps Profiles
+	want := fmt.Sprintf("%s=profile-iface", iface)
+	if err := ps.Set(want); err != nil {
+		t.Fatalf("Profiles.Set(%s) = Err %v", want, err)
+	}
+
+	got := ps.Strings()
+	if len(got) != 1 {
+		t.Fatalf("len(Profiles.Strings()) = %d, want 1", len(got))
+	}
+	if got[0] != want {
+		t.Fatalf("Profiles.Strings()[0] = %q, want %q", got[0], want)
+	}
+}
+
+func TestConfigWrite_PreservesInterfaceProfile(t *testing.T) {
+	iface := loopbackInterfaceName(t)
+	want := fmt.Sprintf("profile %s=profile-iface\n", iface)
+
+	var c Config
+	if err := c.Profile.Set(fmt.Sprintf("%s=profile-iface", iface)); err != nil {
+		t.Fatalf("Config.Profile.Set() = Err %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := c.Write(&buf); err != nil {
+		t.Fatalf("Config.Write() = Err %v", err)
+	}
+	if got := buf.String(); !bytes.Contains([]byte(got), []byte(want)) {
+		t.Fatalf("Config.Write() missing %q in %q", want, got)
+	}
+}
+
+func loopbackInterfaceName(t *testing.T) string {
+	t.Helper()
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatalf("net.Interfaces() = Err %v", err)
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+		return iface.Name
+	}
+	t.Skip("no loopback interface with addresses found")
+	return ""
 }


### PR DESCRIPTION
Interface based profile rules do not round-trip through config output.

Repro
1. Pick any real interface name. `lo` is enough on a normal box.
2. Run `nextdns config set -profile lo=abcdef`
3. Run `nextdns config list`
4. The output shows `profile abcdef`, so the `lo=` selector gets dropped.

This is easy to hit in practice. Interface selectors are documented, and real router-ish setups always have names like `lo`, `eth0`, `br-lan`, `en0`, etc. No weird quota or hard limit makes this unreachable, its just a normal config path.

Fix
- keep the interface name when parsing interface based rules
- stringify and replace those rules by interface name, so config output round-trips cleanly

Tests
- add regression coverage for `Profiles.Strings()`
- add regression coverage for `Config.Write()`

`go test ./...` is green. Kinda small, but this was a footgun.
