### PR TITLE
feat: warn when client discovery is disabled by loopback-only listen

### DIFF
--- a/run.go
+++ b/run.go
@@ -344,7 +344,7 @@ func run(args []string) error {
 		// the local host or if setup router is on.
 		enableDiscovery := !localhostMode
 		if !enableDiscovery {
-			log.Warningf("report-client-info is enabled but client discovery is disabled because nextdns is listening on a loopback address only (%s); devices will appear in the dashboard without names. Set a non-loopback listen address (e.g. 0.0.0.0:53) to enable discovery.", strings.Join(c.Listens, ", "))
+			log.Warningf("report-client-info is enabled but client discovery is disabled because NextDNS is listening on a loopback address only (%s); devices will appear in the dashboard without names. Set a non-loopback listen address (e.g. 0.0.0.0:53) to enable discovery.", strings.Join(c.Listens, ", "))
 		}
 		var r discovery.Resolver
 		if enableDiscovery {

--- a/run.go
+++ b/run.go
@@ -343,6 +343,9 @@ func run(args []string) error {
 		// Only enable discovery if configured to listen to requests outside
 		// the local host or if setup router is on.
 		enableDiscovery := !localhostMode
+		if !enableDiscovery {
+			log.Warningf("report-client-info is enabled but client discovery is disabled because nextdns is listening on a loopback address only (%s); devices will appear in the dashboard without names. Set a non-loopback listen address (e.g. 0.0.0.0:53) to enable discovery.", strings.Join(c.Listens, ", "))
+		}
 		var r discovery.Resolver
 		if enableDiscovery {
 			discoverDHCP := &discovery.DHCP{OnError: func(err error) { log.Errorf("dhcp: %v", err) }}


### PR DESCRIPTION
Closes #1071.

When `report-client-info` is enabled but nextdns listens only on a loopback address, client discovery is silently skipped — devices then appear in the dashboard with random IDs and no hostnames, with nothing in the logs to explain why.

This adds a `Warningf` at startup in that branch so the misconfiguration is visible. Behavior is otherwise unchanged: a loopback-only listen still disables discovery, as intended.

Verification: `go build ./...`, `go vet ./...`, `go test .`, and linux/windows cross-compiles all pass.
