### PR TITLE
feat: add dinit init system support

### DIFF
--- a/host/service/dinit/service.go
+++ b/host/service/dinit/service.go
@@ -53,12 +53,12 @@ func (s Service) Install() error {
 }
 
 func (s Service) Uninstall() error {
-	_ = internal.Run("dinitctl", "disable", s.Name)
+	errDisable := internal.Run("dinitctl", "disable", s.Name)
 	_ = os.Remove(s.EnvPath)
 	if err := os.Remove(s.Path); err != nil {
 		return err
 	}
-	return nil
+	return errDisable
 }
 
 func (s Service) Status() (service.Status, error) {

--- a/host/service/dinit/service.go
+++ b/host/service/dinit/service.go
@@ -1,0 +1,101 @@
+// Package dinit implements the dinit init system.
+
+package dinit
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nextdns/nextdns/host/service"
+	"github.com/nextdns/nextdns/host/service/internal"
+)
+
+type Service struct {
+	service.Config
+	service.ConfigFileStorer
+	Path    string
+	EnvPath string
+}
+
+func New(c service.Config) (Service, error) {
+	if b, _ := os.ReadFile("/proc/1/comm"); !bytes.Equal(b, []byte("dinit\n")) {
+		return Service{}, service.ErrNotSupported
+	}
+	if _, err := exec.LookPath("dinitctl"); err != nil {
+		return Service{}, service.ErrNotSupported
+	}
+
+	return Service{
+		Config:           c,
+		ConfigFileStorer: service.ConfigFileStorer{File: "/etc/" + c.Name + ".conf"},
+		Path:             "/etc/dinit.d/" + c.Name,
+		EnvPath:          "/etc/dinit.d/" + c.Name + ".env",
+	}, nil
+}
+
+func (s Service) Install() error {
+	if err := internal.CreateWithTemplate(s.Path, tmpl, 0644, s.Config); err != nil {
+		return err
+	}
+	if err := os.WriteFile(s.EnvPath, []byte(service.RunModeEnv+"=1\n"), 0644); err != nil {
+		_ = os.Remove(s.Path)
+		return err
+	}
+	if err := internal.Run("dinitctl", "enable", s.Name); err != nil {
+		_ = os.Remove(s.Path)
+		_ = os.Remove(s.EnvPath)
+		return err
+	}
+	return nil
+}
+
+func (s Service) Uninstall() error {
+	_ = internal.Run("dinitctl", "disable", s.Name)
+	_ = os.Remove(s.EnvPath)
+	if err := os.Remove(s.Path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s Service) Status() (service.Status, error) {
+	out, err := internal.RunOutput("dinitctl", "status", s.Name)
+	if err != nil {
+		if os.Geteuid() != 0 {
+			return service.StatusUnknown, errors.New("permission denied")
+		}
+		return service.StatusUnknown, err
+	}
+
+	switch {
+	case strings.Contains(out, "STARTED"):
+		return service.StatusRunning, nil
+	case strings.Contains(out, "STOPPED"):
+		return service.StatusStopped, nil
+	default:
+		return service.StatusNotInstalled, nil
+	}
+}
+
+func (s Service) Start() error   { return ctl("start", s.Name) }
+func (s Service) Stop() error    { return ctl("stop", s.Name) }
+func (s Service) Restart() error { return ctl("restart", s.Name) }
+
+func ctl(action, name string) error {
+	if err := internal.Run("dinitctl", action, name); err != nil {
+		if os.Geteuid() != 0 {
+			return errors.New("permission denied")
+		}
+		return err
+	}
+	return nil
+}
+
+var tmpl = `type = process
+command = {{.Executable}}{{range .Arguments}} {{.}}{{end}}
+env-file = /etc/dinit.d/{{.Name}}.env
+restart = true
+`

--- a/host/service_linux.go
+++ b/host/service_linux.go
@@ -3,6 +3,7 @@ package host
 import (
 	"github.com/nextdns/nextdns/host/service"
 	"github.com/nextdns/nextdns/host/service/ddwrt"
+	"github.com/nextdns/nextdns/host/service/dinit"
 	"github.com/nextdns/nextdns/host/service/edgeos"
 	"github.com/nextdns/nextdns/host/service/entware"
 	"github.com/nextdns/nextdns/host/service/firewalla"
@@ -55,6 +56,9 @@ func NewService(c service.Config) (service.Service, error) {
 		return s, nil
 	}
 	if s, err := upstart.New(c); err == nil {
+		return s, nil
+	}
+	if s, err := dinit.New(c); err == nil {
 		return s, nil
 	}
 	if s, err := sysv.New(c); err == nil {


### PR DESCRIPTION
Closes #1099.

Adds a dinit service backend so `nextdns install/uninstall/start/stop/restart/status` work on dinit-based systems such as Artix Linux, mirroring the existing init backends.

- Detects dinit as PID 1 via `/proc/1/comm`.
- Writes a service description to `/etc/dinit.d/<name>` and passes `SERVICE_RUN_MODE=1` via an `env-file` sidecar (dinit service descriptions don't support inline env directives), matching the convention used by the systemd/openrc/procd/sysv backends.
- Enables at boot and drives the service via `dinitctl`; install rolls back partial state on failure.
- Wired into `host/service_linux.go`; no existing backend changed; no new dependencies.

Verification: `go build ./...`, `go vet ./...`, `go test ./host/...`, and linux/windows/darwin cross-compiles all pass. Manual install/start/status on a live dinit host still to be confirmed.
