### PR TITLE
feat: add shell completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ NextDNS CLI is a command-line tool that allows you to use [NextDNS](https://next
 This CLI is mostly aimed at routers and UNIX based systems, but it is also a great client for Windows and macOS, especially for people who prefer a fully open-source client and don't mind the lack of a GUI.
 
 See the [wiki](https://github.com/nextdns/nextdns/wiki) for installation and usage instructions.
+
+### Shell completion
+
+```sh
+nextdns completion bash | sudo tee /etc/bash_completion.d/nextdns
+nextdns completion zsh  > "${fpath[1]}/_nextdns"
+nextdns completion fish > ~/.config/fish/completions/nextdns.fish
+```

--- a/completion.go
+++ b/completion.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func completion(args []string) error {
+	shell := ""
+	if len(args) > 1 {
+		shell = args[1]
+	}
+	script, err := completionScript(shell)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "Usage: nextdns completion <bash|zsh|fish>")
+		os.Exit(1)
+	}
+	fmt.Print(script)
+	return nil
+}
+
+func completionScript(shell string) (string, error) {
+	var names []string
+	for _, c := range commands {
+		names = append(names, c.name)
+	}
+	cmds := strings.Join(names, " ")
+	switch shell {
+	case "bash":
+		return fmt.Sprintf(bashCompletion, cmds), nil
+	case "zsh":
+		return fmt.Sprintf(zshCompletion, cmds), nil
+	case "fish":
+		return fmt.Sprintf(fishCompletion, cmds), nil
+	default:
+		return "", fmt.Errorf("unsupported or missing shell: %q", shell)
+	}
+}
+
+const bashCompletion = `_nextdns() {
+    local cur
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if [ "$COMP_CWORD" -eq 1 ]; then
+        COMPREPLY=( $(compgen -W "%s" -- "$cur") )
+        return 0
+    fi
+    if [ "${COMP_WORDS[1]}" = "config" ] && [ "$COMP_CWORD" -eq 2 ]; then
+        COMPREPLY=( $(compgen -W "list set edit wizard" -- "$cur") )
+    fi
+}
+complete -F _nextdns nextdns
+`
+
+const zshCompletion = `#compdef nextdns
+_nextdns() {
+    if (( CURRENT == 2 )); then
+        compadd -- %s
+        return
+    fi
+    if [[ ${words[2]} == config && CURRENT == 3 ]]; then
+        compadd -- list set edit wizard
+    fi
+}
+compdef _nextdns nextdns
+`
+
+const fishCompletion = `complete -c nextdns -f
+complete -c nextdns -n __fish_use_subcommand -a '%s'
+complete -c nextdns -n '__fish_seen_subcommand_from config' -a 'list set edit wizard'
+`

--- a/completion_test.go
+++ b/completion_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompletionScript(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		s, err := completionScript(shell)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", shell, err)
+		}
+		if s == "" {
+			t.Fatalf("%s: empty script", shell)
+		}
+		if !strings.Contains(s, "nextdns") {
+			t.Errorf("%s: script missing program name", shell)
+		}
+		if !strings.Contains(s, "install") {
+			t.Errorf("%s: script missing known command", shell)
+		}
+	}
+	if _, err := completionScript("powershell"); err == nil {
+		t.Error("expected error for unsupported shell")
+	}
+	if _, err := completionScript(""); err == nil {
+		t.Error("expected error for missing shell")
+	}
+}

--- a/completion_test.go
+++ b/completion_test.go
@@ -20,6 +20,9 @@ func TestCompletionScript(t *testing.T) {
 		if !strings.Contains(s, "install") {
 			t.Errorf("%s: script missing known command", shell)
 		}
+		if !strings.Contains(s, "list set edit wizard") {
+			t.Errorf("%s: script missing config subcommands", shell)
+		}
 	}
 	if _, err := completionScript("powershell"); err == nil {
 		t.Error("expected error for unsupported shell")

--- a/main.go
+++ b/main.go
@@ -17,32 +17,38 @@ type command struct {
 	desc string
 }
 
-var commands = []command{
-	{"install", svc, "install service init on the system"},
-	{"uninstall", svc, "uninstall service init from the system"},
-	{"start", svc, "start installed service"},
-	{"stop", svc, "stop installed service"},
-	{"restart", svc, "restart installed service"},
-	{"status", svc, "return service status"},
-	{"log", svc, "show service logs"},
+var commands []command
 
-	{"upgrade", upgrade, "upgrade the cli to the latest version"},
+func init() {
+	commands = []command{
+		{"install", svc, "install service init on the system"},
+		{"uninstall", svc, "uninstall service init from the system"},
+		{"start", svc, "start installed service"},
+		{"stop", svc, "stop installed service"},
+		{"restart", svc, "restart installed service"},
+		{"status", svc, "return service status"},
+		{"log", svc, "show service logs"},
 
-	{"run", run, "run the daemon"},
+		{"upgrade", upgrade, "upgrade the cli to the latest version"},
 
-	{"config", cfg, "manage configuration"},
+		{"run", run, "run the daemon"},
 
-	{"activate", activation, "setup the system to use NextDNS as a resolver"},
-	{"deactivate", activation, "restore the resolver configuration"},
+		{"config", cfg, "manage configuration"},
 
-	{"discovered", ctlCmd, "display discovered clients"},
-	{"cache-stats", ctlCmd, "display cache statistics"},
-	{"cache-keys", ctlCmd, "dump the list of cached entries"},
-	{"trace", ctlCmd, "display a stack trace dump"},
-	{"arp", ctlCmd, "dump the ARP table"},
-	{"ndp", ctlCmd, "dump the NDP table"},
+		{"activate", activation, "setup the system to use NextDNS as a resolver"},
+		{"deactivate", activation, "restore the resolver configuration"},
 
-	{"version", showVersion, "show current version"},
+		{"discovered", ctlCmd, "display discovered clients"},
+		{"cache-stats", ctlCmd, "display cache statistics"},
+		{"cache-keys", ctlCmd, "dump the list of cached entries"},
+		{"trace", ctlCmd, "display a stack trace dump"},
+		{"arp", ctlCmd, "dump the ARP table"},
+		{"ndp", ctlCmd, "dump the NDP table"},
+
+		{"version", showVersion, "show current version"},
+
+		{"completion", completion, "generate shell completion script (bash|zsh|fish)"},
+	}
 }
 
 func showCommands() {


### PR DESCRIPTION
Closes #1051.

Adds `nextdns completion <bash|zsh|fish>`, which prints a shell completion script for the given shell. Completion covers the top-level commands (derived from the existing commands table, so it stays in sync) and the `config` subcommands (`list`, `set`, `edit`, `wizard`).

- `completion.go`: pure `completionScript()` generator plus a thin command wrapper.
- `completion_test.go`: unit tests for all three shells and the error cases.
- `main.go`: registers the command (the commands table moves to `init()` to avoid an initialization cycle).
- `README.md`: documents how to install the script.

Verification: `go build ./...`, `go vet ./...`, `go test .`, `nextdns completion bash | bash -n`, and linux/windows cross-compiles all pass.
