### PR TITLE
fix(run): keep the daemon responsive when activation blocks at startup

### DIFF
--- a/run.go
+++ b/run.go
@@ -67,9 +67,20 @@ func (p *proxySvc) Start() (err error) {
 		}
 		break
 	}
-	for _, f := range p.OnStarted {
-		f()
-	}
+	// Run OnStarted off the Start() critical path. activate() and router.Setup()
+	// do unbounded blocking I/O; a single hung call must not prevent Start() from
+	// returning. A goroutine preserves their sequential order without gating startup
+	// (they already log-and-continue on error). See TestStartDoesNotBlockOnSlowOnStarted.
+	//
+	// Known limitation: Stop() does not join this goroutine, so a slow activate()
+	// may SetDNS after deactivate() ran -- a narrow, self-correcting ordering hazard
+	// (still better than the old hang, which SIGKILL'd before deactivate could run).
+	// A follow-up closes it by threading start()'s ctx for a bounded cancel-and-join.
+	go func() {
+		for _, f := range p.OnStarted {
+			f()
+		}
+	}()
 	return nil
 }
 
@@ -85,18 +96,21 @@ func isErrNetUnreachable(err error) bool {
 	return false
 }
 
-func (p *proxySvc) start() (err error) {
+func (p *proxySvc) start() error {
 	errC := make(chan error)
-	var ctx context.Context
+	// Create the cancel context and stop signalling channel synchronously, before
+	// the goroutine, so Stop()/Restart() on another goroutine never race the
+	// writes to p.stopFunc/p.stopped (go test -race flags it otherwise).
+	ctx, cancel := context.WithCancel(context.Background())
+	p.stopFunc = cancel
+	p.stopped = make(chan struct{})
 	go func() {
-		ctx, p.stopFunc = context.WithCancel(context.Background())
-		defer p.stopFunc()
-		p.stopped = make(chan struct{})
+		defer cancel()
 		defer close(p.stopped)
 		for _, f := range p.OnInit {
 			go f(ctx)
 		}
-		if err = p.ListenAndServe(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		if err := p.ListenAndServe(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			select {
 			case errC <- err:
 			default:

--- a/run_onstarted_test.go
+++ b/run_onstarted_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/nextdns/nextdns/host"
+)
+
+// TestStartDoesNotBlockOnSlowOnStarted proves the startup wedge and its fix.
+//
+// activate() and router.Setup() run as OnStarted callbacks. They do unbounded
+// blocking I/O (networksetup/netsh/systemctl/uci, systemd-resolved D-Bus). If
+// one hangs, Start() must still return: it is called synchronously by
+// runService (host/service/run_unix.go) BEFORE the signal-handling loop runs,
+// so a Start() that never returns leaves the daemon printing "Activating"
+// forever AND unable to handle SIGTERM -- systemctl stop/restart then hangs
+// until SIGKILL.
+//
+// synctest gives a fake clock so start()'s 5s listener grace costs no real time
+// and the assertion is deterministic rather than racing a wall clock.
+func TestStartDoesNotBlockOnSlowOnStarted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		p := &proxySvc{
+			log: host.NewConsoleLogger("test"),
+			OnStarted: []func(){
+				func() { <-release }, // stand-in for a hung SetDNS / router Setup
+			},
+		}
+
+		done := make(chan struct{})
+		go func() {
+			_ = p.Start()
+			close(done)
+		}()
+
+		// Under synctest the clock only advances when goroutines block on time,
+		// so this select fake-fires start()'s 5s grace, then either observes
+		// Start() return (fixed) or trips the sentinel timeout (wedged). Both
+		// timers are virtual: the test spends no real time here.
+		wedged := false
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second): // sentinel >> start()'s 5s grace
+			wedged = true
+		}
+
+		// Tear down regardless of outcome: release the callback so a wedged
+		// Start() can finish, then stop the proxy to cancel the listener ctx --
+		// otherwise synctest panics on leftover blocked goroutines.
+		close(release)
+		<-done
+		p.Stop()
+
+		if wedged {
+			t.Fatal("Start() blocked on a slow OnStarted callback: startup wedges and the daemon cannot handle signals until SIGKILL")
+		}
+	})
+}

--- a/run_onstarted_test.go
+++ b/run_onstarted_test.go
@@ -53,7 +53,7 @@ func TestStartDoesNotBlockOnSlowOnStarted(t *testing.T) {
 		// otherwise synctest panics on leftover blocked goroutines.
 		close(release)
 		<-done
-		p.Stop()
+		_ = p.Stop()
 
 		if wedged {
 			t.Fatal("Start() blocked on a slow OnStarted callback: startup wedges and the daemon cannot handle signals until SIGKILL")
@@ -112,6 +112,6 @@ func TestRestartDoesNotRerunOnStarted(t *testing.T) {
 		if got := runs.Load(); got != 1 {
 			t.Fatalf("OnStarted ran %d times after Restart, want 1 (Restart must not re-run it)", got)
 		}
-		p.Stop()
+		_ = p.Stop()
 	})
 }

--- a/run_onstarted_test.go
+++ b/run_onstarted_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -57,5 +58,60 @@ func TestStartDoesNotBlockOnSlowOnStarted(t *testing.T) {
 		if wedged {
 			t.Fatal("Start() blocked on a slow OnStarted callback: startup wedges and the daemon cannot handle signals until SIGKILL")
 		}
+	})
+}
+
+// TestStopReturnsWhileOnStartedHung verifies the documented limitation is safe:
+// Stop() must not join the detached OnStarted goroutine, so it returns promptly
+// even while a callback is hung -- otherwise a hung activate() would make Stop()
+// wedge exactly like the bug this series removes.
+func TestStopReturnsWhileOnStartedHung(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		release := make(chan struct{})
+		p := &proxySvc{
+			log:       host.NewConsoleLogger("test"),
+			OnStarted: []func(){func() { <-release }},
+		}
+		if err := p.Start(); err != nil { // fake clock advances start()'s 5s grace
+			t.Fatalf("Start: %v", err)
+		}
+
+		stopped := make(chan struct{})
+		go func() { _ = p.Stop(); close(stopped) }()
+		select {
+		case <-stopped:
+		case <-time.After(30 * time.Second):
+			close(release)
+			t.Fatal("Stop() blocked while an OnStarted callback was hung")
+		}
+		close(release) // let the detached OnStarted goroutine exit
+	})
+}
+
+// TestRestartDoesNotRerunOnStarted confirms OnStarted fires exactly once per
+// process: Restart() goes through start(), not Start(), so activation/router
+// setup must not re-run (and must not accumulate goroutines) on restart.
+func TestRestartDoesNotRerunOnStarted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var runs atomic.Int32
+		p := &proxySvc{
+			log:       host.NewConsoleLogger("test"),
+			OnStarted: []func(){func() { runs.Add(1) }},
+		}
+		if err := p.Start(); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		synctest.Wait() // let the OnStarted goroutine run
+		if got := runs.Load(); got != 1 {
+			t.Fatalf("OnStarted ran %d times after Start, want 1", got)
+		}
+		if err := p.Restart(); err != nil {
+			t.Fatalf("Restart: %v", err)
+		}
+		synctest.Wait()
+		if got := runs.Load(); got != 1 {
+			t.Fatalf("OnStarted ran %d times after Restart, want 1 (Restart must not re-run it)", got)
+		}
+		p.Stop()
 	})
 }


### PR DESCRIPTION
## Status

Draft, and a partial fix. It keeps the daemon responsive to signals while activation blocks at startup, but it does not on its own guarantee the process exits: the shutdown path performs the same unbounded DNS calls, so the block moves from startup to shutdown rather than disappearing. A follow-up that bounds those calls is what actually closes the hang. Details below.

## What & why

`nextdns run` can hang on `Activating` indefinitely while still reporting healthy, recoverable only by SIGKILL. Same class as the endpoint-manager deadlock fixed in #1111: unbounded blocking work on a critical path.

The cause is structural. `service.Run` calls `Start()` before its signal loop begins (`host/service/run_unix.go`), and `Start()` ran the `OnStarted` callbacks (`activate()` -> `host.SetDNS` via `networksetup`/`netsh`/`resolvconf`/`nmcli`/systemd-resolved D-Bus, plus `router.Setup()` under `-setup-router`) inline before returning. So one hung call wedges startup on `Activating` and leaves the daemon deaf to SIGTERM.

## Fix

Run `OnStarted` in a background goroutine so `Start()` returns promptly and the signal loop stays live. Activation proceeds, or fails and logs, in the background, matching its existing log-and-continue behaviour.

## What it does and does not do

Does: the signal handler is installed while activation runs, so SIGTERM is handled instead of ignored. That is the startup half of the problem.

Does not: guarantee shutdown completes. `Stop()` runs `deactivate()`, which calls the same unbounded per-platform DNS operations that `activate()` does, so a hung call now blocks shutdown instead of startup. This change does not bound those calls. A self-contained follow-up does (`exec.CommandContext` + `cmd.WaitDelay`) and joins activation on stop; that is where the hang is actually closed.

Trade-off: `Stop()` no longer joins the activation goroutine, so a still-running `activate()` could re-apply DNS just after `deactivate()`. The follow-up closes that too.

## Verification

`testing/synctest` (fake clock, `-race`): `Start()` returns despite a hung `OnStarted`, and `Restart()` does not re-run it. End to end on the built binary with a stub `networksetup` that blocks (isolated loopback, real DNS untouched): pre-fix, SIGTERM hard-kills with no graceful shutdown; post-fix, the signal loop runs and reaches `Stopping`. The foreground SIGTERM path is observed directly. The service-mode `systemctl` -> SIGKILL path follows from the same signal ordering and was not staged.
