### PR TITLE
bug: fix Firewalla service killed at boot and left unsupervised

### DIFF
--- a/host/service/firewalla/service.go
+++ b/host/service/firewalla/service.go
@@ -81,14 +81,9 @@ var tmpl = `#!/bin/bash
 cmd="{{.Executable}}{{range .Arguments}} {{.}}{{end}}"
 
 name={{.Name}}
-pid_file="/home/pi/firewalla/run/$name.pid"
-
-get_pid() {
-	cat "$pid_file"
-}
 
 is_running() {
-	[ -f "$pid_file" ] && ps $(get_pid) > /dev/null 2>&1
+	systemctl is-active --quiet "$name"
 }
 
 action=$1
@@ -102,11 +97,14 @@ case "$action" in
 			echo "Already started"
 		else
 			echo "Starting $name"
-			sudo sh -c "
-					export {{.RunModeEnv}}=1
-					$cmd </dev/null >/dev/null 2>&1 &
-					echo \$! > "$pid_file"
-			"
+			sudo systemctl reset-failed "$name" 2>/dev/null
+			sudo pkill -x "$name" 2>/dev/null
+			sudo systemd-run --quiet --unit="$name" \
+				--property=Environment={{.RunModeEnv}}=1 \
+				--property=Restart=on-failure \
+				--property=RestartSec=5 \
+				$cmd
+			sleep 1
 			if ! is_running; then
 				echo "Unable to start"
 				exit 1
@@ -115,36 +113,23 @@ case "$action" in
 	;;
 	stop)
 		if is_running; then
-			echo -n "Stopping $name.."
-			sudo kill $(get_pid)
-			for i in 1 2 3 4 5 6 7 8 9 10; do
-				if ! is_running; then
-					break
-				fi
-				echo -n "."
-				sleep 1
-			done
-			echo
+			echo "Stopping $name"
+			sudo systemctl stop "$name"
 			if is_running; then
 				echo "Not stopped; may still be shutting down or shutdown may have failed"
 				exit 1
-			else
-				echo "Stopped"
-				if [ -f "$pid_file" ]; then
-					sudo rm "$pid_file"
-				fi
 			fi
+			echo "Stopped"
 		else
 			echo "Not running"
 		fi
 	;;
 	restart)
-		$0 stop
 		if is_running; then
-			echo "Unable to stop, will not attempt to start"
-			exit 1
+			sudo systemctl restart "$name"
+		else
+			$0 start
 		fi
-		$0 start
 	;;
 	status)
 		if is_running; then


### PR DESCRIPTION
## Problem

The Firewalla run script generated by `host/service/firewalla/service.go` starts the daemon as a detached background process tracked by a pidfile. On real hardware (Firewalla Gold, firmware 3.0929, Ubuntu 22.04 / systemd 249) this has three failure modes:

1. **The daemon is killed at boot by systemd's cgroup cleanup.** At boot the script runs from `firewalla.service` (`Type=oneshot`, `KillMode=control-group`, `RemainAfterExit=no`), so the daemon starts inside that unit's control group and is killed as soon as the unit's start-up run exits. With the router-mode dnsmasq snippet (which uses `no-resolv`), that is a total LAN DNS outage after every reboot. (Firewalla's own daemons avoid this by running as separate units.) Reproduction on a Firewalla:

   ```
   sudo systemd-run --unit=t -p Type=oneshot -p KillMode=control-group \
     /bin/sh -c 'sleep 300 </dev/null >/dev/null 2>&1 &'
   # a few seconds later the sleep process has been killed
   ```

2. **Stale pidfile false positives.** `/home/pi/firewalla/run` is on persistent storage, so the pidfile survives reboots. `is_running()` checks `ps $(cat pidfile)` — process existence, not identity — so after a reboot a recycled PID makes `start` print "Already started" without starting anything, and `stop` can `kill` an unrelated process.

3. **No crash recovery.** Nothing restarts a crashed daemon; with `no-resolv`, one crash leaves DNS down until manual intervention.

## Fix

Run the daemon as a transient systemd unit (`systemd-run --unit=<name>`) and delegate stop/status/restart to `systemctl`:

- a transient unit is its own control group, so it survives `firewalla.service` deactivation at boot;
- `Restart=on-failure` / `RestartSec=5` provides crash recovery;
- systemd becomes the source of truth for liveness — no pidfile, so the stale-PID class is gone.

Notes:

- **Template-only change.** The script keeps its interface and output contract (`Already started` / `Running` / `Stopped`, exit codes), so the Go `Status`/`Start`/`Stop`/`Restart` implementations are untouched.
- `systemctl reset-failed` before `systemd-run` prevents "unit already exists" after a previously failed run.
- A one-time `pkill -x` before start stops any daemon left by the previous pidfile-based script, which would otherwise hold the listen address.
- Logging is unaffected: with `SERVICE_RUN_MODE=1` the daemon logs to syslog tagged with its name, so `nextdns log` (`journalctl -t <name>`) keeps working.
- Firewalla is Ubuntu-based; systemd is always present.

## Behavioral changes and trade-offs

- **Failed starts now retry.** Previously a failed start printed "Unable to start" once and gave up — at boot, a listen address not yet assigned or a network not yet up left the daemon down until manual intervention. With `Restart=on-failure`/`RestartSec=5` these start-up ordering races self-heal within seconds. The flip side: a genuinely persistent failure also retries every 5 s (a pace that never trips systemd's default start rate-limit); add `StartLimitIntervalSec`/`StartLimitBurst` if a cap is preferred.
- **`restart`** uses `systemctl restart` when the unit is running (transient unit properties survive a restart) and falls back to `$0 start` when it is not; previously stop-then-start.
- **`stop`** drops the 10-second poll loop — `systemctl stop` is synchronous. Output text differs slightly; the Go side only parses the `status` verb's prefixes, which are unchanged.
- **The post-start check waits 1 s**; a daemon that fails more slowly is reported as started and left to systemd's restart logic. The previous script checked immediately, which raced in the opposite direction.
- **`pkill -x "$name"` assumes process name == service name** — true because the installer names the binary `<name>`. It also terminates a manually started foreground `nextdns run`. The alternative is omitting it and letting a pre-upgrade daemon hold the listen address while the new unit crash-retries behind it.

## Testing

- The generated script (template rendered with its install-time values) passes `bash -n`.
- The same architecture (identical `systemd-run` invocation) has been running on a production Firewalla Gold: survives reboot (daemon up within a minute; dnsmasq→daemon forwarding verified end-to-end at +5 and +30 minutes), respawns ~5 s after `kill -9`, and start/stop/restart cycles keep the daemon under the unit with correct script output.

