### PR TITLE
feat: add Firewalla dnsmasq lease file to DHCP discovery

### DIFF
--- a/discovery/dhcp.go
+++ b/discovery/dhcp.go
@@ -26,6 +26,7 @@ var leaseFiles = []leaseFile{
 	{"/config/dhcpd.leases", "dnsmasq"},
 	{"/var/lib/dnsmasq/dhcp.leases", "dnsmasq"},
 	{"/data/udapi-config/dnsmasq.lease", "dnsmasq"},
+	{"/home/pi/.router/run/dhcp/dnsmasq.leases", "dnsmasq"},
 }
 
 type DHCP struct {


### PR DESCRIPTION
## Problem

Firewalla's firerouter writes dnsmasq DHCP leases to `/home/pi/.router/run/dhcp/dnsmasq.leases`. This path is not in the `leaseFiles` list probed by `discovery/dhcp.go`, so lease-based client-name discovery never engages on Firewalla and naming relies solely on the redis-based discovery (`discovery/firewalla_linux.go`), which refreshes every 5 minutes.

## Fix

Add the Firewalla lease path to the probed list. The lease file provides fresher name/MAC/IP data between redis refreshes and covers hosts the redis client list may lack. The path cannot exist on other platforms, so the entry is inert elsewhere — consistent with the existing platform-specific entries in the list (e.g. `/data/udapi-config/dnsmasq.lease`).

Ordering note: `findLeaseFile()` returns the first existing entry, so this path is appended last — it can never shadow an existing entry on any platform where one of the earlier paths is present.

## Testing

Verified on a Firewalla Gold (firmware 3.0929) that the lease file exists at this path, is written by the firerouter-managed dnsmasq, and is in standard dnsmasq lease format.

