### PR TITLE
feat: make the nextdns command available on PATH on Firewalla

### DIFF
--- a/host/service/firewalla/service.go
+++ b/host/service/firewalla/service.go
@@ -81,6 +81,7 @@ var tmpl = `#!/bin/bash
 cmd="{{.Executable}}{{range .Arguments}} {{.}}{{end}}"
 
 name={{.Name}}
+exe="{{.Executable}}"
 
 is_running() {
 	systemctl is-active --quiet "$name"
@@ -97,6 +98,8 @@ case "$action" in
 			echo "Already started"
 		else
 			echo "Starting $name"
+			sudo ln -nsf "$exe" "/usr/local/bin/$name"
+			sudo rm -f "/home/pi/firewalla/run/$name.pid"
 			sudo systemctl reset-failed "$name" 2>/dev/null
 			sudo pkill -x "$name" 2>/dev/null
 			sudo systemd-run --quiet --unit="$name" \


### PR DESCRIPTION
## Problem

On Firewalla, `install.sh` keeps the binary at its `bin_location`
(`/home/pi/.firewalla/config/nextdns/nextdns`) and — unlike the other install
targets — never links it into a PATH directory. The documented `nextdns
status` / `nextdns log` / `nextdns upgrade` commands therefore fail with
"command not found" unless the user types the full path.

A one-time symlink at install time would not fix it: `/usr/local` on Firewalla
is a memory-backed overlay cleared at every reboot, so the link has to be
refreshed by something that runs at boot.

## Fix

Two lines in the run script's `start` action, which already executes on every
boot via `post_main.d`:

- `ln -nsf` a `/usr/local/bin/$name` symlink to the installed binary before
  starting the daemon. Idempotent; re-created each boot, which is exactly what
  the volatile overlay requires.
- Remove the legacy pidfile (`/home/pi/firewalla/run/$name.pid`) written by
  pre-#1113 versions of this script. Nothing reads it since #1113, and a stale
  pid there is misleading when debugging.

## Behavioral changes and trade-offs

- `nextdns <command>` works as documented after every boot, with no manual
  step. Previously each reboot silently removed any symlink the user created.
- The symlink is only refreshed when the service starts; that is the same
  lifecycle as the daemon itself, so a present daemon implies a working CLI.

## Testing

- Rendered script (placeholders substituted) passes `bash -n`.
- The same symlink-refresh step has been running at every boot on a production
  Firewalla Gold since 2026-07-10 via an equivalent boot script, alongside the
  #1113 supervision model, with no issues observed.
